### PR TITLE
Fix build error when building against ITKv5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,12 @@ cmake_minimum_required(VERSION 2.8.9)
 
 project(ResampleDTIlogEuclidean)
 
-include( CTest )
+include(CTest)
 include(ExternalData)
 
+#-----------------------------------------------------------------------------
 # Set a default build type if none was specified
+#-----------------------------------------------------------------------------
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to 'Release' as none was specified.")
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
@@ -13,18 +15,20 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
-if( ResampleDTIlogEuclidean_BUILD_SLICER_EXTENSION )
-  #-----------------------------------------------------------------------------
-  # Extension meta-information
-  set(EXTENSION_HOMEPAGE "http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ResampleDTIlogEuclidean")
-  set(EXTENSION_CATEGORY "Diffusion")
-  set(EXTENSION_CONTRIBUTORS "Francois Budin (UNC), Sylvain Bouix (PNL)")
-  set(EXTENSION_DESCRIPTION "ResampleDTIlogEuclidean resamples Diffusion Tensor Images (DTI) in the log-euclidean framework. More information is available in the Insight Journal: http://www.insight-journal.org/browse/publication/742")
-  set(EXTENSION_ICONURL "http://www.slicer.org/slicerWiki/images/1/13/ResampleDTIlogEuclidean-128x128-icon.png")
-  set(EXTENSION_SCREENSHOTURLS "http://www.slicer.org/slicerWiki/images/4/41/ResampleDTI-Slice_extracted_from_a_real_Diffusion_Tensor_Image_-_No_transformation.png" "http://www.slicer.org/slicerWiki/images/8/87/ResampleDTI-Real_DTI_transformed_with_a_45deg_rotation_-_Linear_interpolation.png" "http://www.slicer.org/slicerWiki/images/1/14/ResampleDTI-Real_DTI_upscaled_with_a_factor_2_-_Linear_interpolation.png")
+#-----------------------------------------------------------------------------
+# Extension meta-information
+#-----------------------------------------------------------------------------
+set(EXTENSION_HOMEPAGE "http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ResampleDTIlogEuclidean")
+set(EXTENSION_CATEGORY "Diffusion")
+set(EXTENSION_CONTRIBUTORS "Francois Budin (UNC), Sylvain Bouix (PNL)")
+set(EXTENSION_DESCRIPTION "ResampleDTIlogEuclidean resamples Diffusion Tensor Images (DTI) in the log-euclidean framework. More information is available in the Insight Journal: http://www.insight-journal.org/browse/publication/742")
+set(EXTENSION_ICONURL "http://www.slicer.org/slicerWiki/images/1/13/ResampleDTIlogEuclidean-128x128-icon.png")
+set(EXTENSION_SCREENSHOTURLS "http://www.slicer.org/slicerWiki/images/4/41/ResampleDTI-Slice_extracted_from_a_real_Diffusion_Tensor_Image_-_No_transformation.png" "http://www.slicer.org/slicerWiki/images/8/87/ResampleDTI-Real_DTI_transformed_with_a_45deg_rotation_-_Linear_interpolation.png" "http://www.slicer.org/slicerWiki/images/1/14/ResampleDTI-Real_DTI_upscaled_with_a_factor_2_-_Linear_interpolation.png")
 
-  #-----------------------------------------------------------------------------
-  # Extension dependencies
+#-----------------------------------------------------------------------------
+# Extension dependencies
+#-----------------------------------------------------------------------------
+if(ResampleDTIlogEuclidean_BUILD_SLICER_EXTENSION)
   find_package(Slicer REQUIRED)
   include(${Slicer_USE_FILE})
   set(STATIC_RESAMPLEDTI OFF CACHE BOOL "Build static ResampleDTIlogEuclidean" FORCE )
@@ -35,6 +39,6 @@ endif()
 add_subdirectory(Source)
 
 #-----------------------------------------------------------------------------
-if( ResampleDTIlogEuclidean_BUILD_SLICER_EXTENSION )
+if(ResampleDTIlogEuclidean_BUILD_SLICER_EXTENSION)
   include(${Slicer_EXTENSION_CPACK})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,31 @@ set(EXTENSION_ICONURL "http://www.slicer.org/slicerWiki/images/1/13/ResampleDTIl
 set(EXTENSION_SCREENSHOTURLS "http://www.slicer.org/slicerWiki/images/4/41/ResampleDTI-Slice_extracted_from_a_real_Diffusion_Tensor_Image_-_No_transformation.png" "http://www.slicer.org/slicerWiki/images/8/87/ResampleDTI-Real_DTI_transformed_with_a_45deg_rotation_-_Linear_interpolation.png" "http://www.slicer.org/slicerWiki/images/1/14/ResampleDTI-Real_DTI_upscaled_with_a_factor_2_-_Linear_interpolation.png")
 
 #-----------------------------------------------------------------------------
+# Standalone vs Slicer extension option
+#-----------------------------------------------------------------------------
+
+# This option should be named after the project name, it corresponds to the
+# option set to ON when the project is build by the Slicer Extension build
+# system.
+
+set(_default OFF)
+set(_reason "${PROJECT_NAME}_BUILD_SLICER_EXTENSION is ON")
+if(NOT DEFINED ${PROJECT_NAME}_BUILD_SLICER_EXTENSION AND DEFINED Slicer_DIR)
+  set(_default ON)
+  set(_reason "Slicer_DIR is SET")
+endif()
+
+option(${PROJECT_NAME}_BUILD_SLICER_EXTENSION "Build as a Slicer Extension" ${_default})
+
+set(_msg "Checking if building as a Slicer extension")
+message(STATUS ${_msg})
+if(${PROJECT_NAME}_BUILD_SLICER_EXTENSION)
+  message(STATUS "${_msg} - yes (${_reason})")
+else()
+  message(STATUS "${_msg} - no (${PROJECT_NAME}_BUILD_SLICER_EXTENSION is OFF)")
+endif()
+
+#-----------------------------------------------------------------------------
 # Extension dependencies
 #-----------------------------------------------------------------------------
 if(ResampleDTIlogEuclidean_BUILD_SLICER_EXTENSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,8 @@ if(ResampleDTIlogEuclidean_BUILD_SLICER_EXTENSION)
 endif()
 option(ResampleDTIlogEuclidean_STATIC_RESAMPLEDTI "Build static ResampleDTIlogEuclidean" ${_default})
 
+set(CMAKE_INCLUDE_CURRENT_DIR 1)
+
 #-----------------------------------------------------------------------------
 # Extension modules
 add_subdirectory(Source)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.10.2)
 
 project(ResampleDTIlogEuclidean)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,16 @@ set(EXTENSION_SCREENSHOTURLS "http://www.slicer.org/slicerWiki/images/4/41/Resam
 if(ResampleDTIlogEuclidean_BUILD_SLICER_EXTENSION)
   find_package(Slicer REQUIRED)
   include(${Slicer_USE_FILE})
-  set(STATIC_RESAMPLEDTI OFF CACHE BOOL "Build static ResampleDTIlogEuclidean" FORCE )
 endif()
+
+#-----------------------------------------------------------------------------
+# Build option(s)
+#-----------------------------------------------------------------------------
+set(_default ON)
+if(ResampleDTIlogEuclidean_BUILD_SLICER_EXTENSION)
+  set(_default OFF)
+endif()
+option(ResampleDTIlogEuclidean_STATIC_RESAMPLEDTI "Build static ResampleDTIlogEuclidean" ${_default})
 
 #-----------------------------------------------------------------------------
 # Extension modules

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -81,5 +81,5 @@ export(TARGETS ${MODULE_NAME} FILE ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}-exp
 option(BUILD_TESTING "Build Testing" ON)
 if(BUILD_TESTING)
   add_subdirectory(Testing)
-endif(BUILD_TESTING)
+endif()
 

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -81,15 +81,15 @@ set(MODULE_TARGET_LIBRARIES
   )
 
 #-----------------------------------------------------------------------------
-option(STATIC_RESAMPLEDTI "Build static ResampleDTIlogEuclidean" ON)
-if(${STATIC_RESAMPLEDTI})
-  set(STATIC "EXECUTABLE_ONLY")
+set(executable_only_option)
+if(${ResampleDTIlogEuclidean_STATIC_RESAMPLEDTI})
+  set(executable_only_option "EXECUTABLE_ONLY")
 endif()
 
 #-----------------------------------------------------------------------------
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
-  ${STATIC}
+  ${executable_only_option}
   ADDITIONAL_SRCS ${MODULE_SRCS}
   TARGET_LIBRARIES ${MODULE_TARGET_LIBRARIES}
   )

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,41 +1,53 @@
+
+#-----------------------------------------------------------------------------
+set(MODULE_NAME ResampleDTIlogEuclidean)
+
+#-----------------------------------------------------------------------------
+
+#
+# SlicerExecutionModel
+#
 find_package(SlicerExecutionModel REQUIRED)
 include(${SlicerExecutionModel_USE_FILE})
 
-set( ALL_IO
-ITKIOBMP
-ITKIOBioRad
-ITKIOCSV
-ITKIODCMTK
-ITKIOGDCM
-ITKIOGE
-ITKIOGIPL
-ITKIOHDF5
-ITKIOIPL
-ITKIOJPEG
-ITKIOLSM
-ITKIOMRC
-ITKIOMesh
-ITKIOMeta
-ITKIONIFTI
-ITKIOPNG
-ITKIORAW
-ITKIOSiemens
-ITKIOSpatialObjects
-ITKIOStimulate
-ITKIOTIFF
-ITKIOTransformHDF5
-ITKIOTransformMatlab
-ITKIOVTK
-ITKIOXML
-MGHIO
-)
+#
+# ITK
+#
+set(ALL_IO
+  ITKIOBMP
+  ITKIOBioRad
+  ITKIOCSV
+  ITKIODCMTK
+  ITKIOGDCM
+  ITKIOGE
+  ITKIOGIPL
+  ITKIOHDF5
+  ITKIOIPL
+  ITKIOJPEG
+  ITKIOLSM
+  ITKIOMRC
+  ITKIOMesh
+  ITKIOMeta
+  ITKIONIFTI
+  ITKIOPNG
+  ITKIORAW
+  ITKIOSiemens
+  ITKIOSpatialObjects
+  ITKIOStimulate
+  ITKIOTIFF
+  ITKIOTransformHDF5
+  ITKIOTransformMatlab
+  ITKIOVTK
+  ITKIOXML
+  MGHIO
+  )
 
 find_package(ITK REQUIRED )
 list(APPEND LIST_ITK_IO_USED ITKIONRRD ITKIOTransformInsightLegacy)
-foreach( io ${ALL_IO} )
-  list( FIND ITK_MODULES_ENABLED ${io} position )
-  if( ${position} GREATER -1 ) #not found: ${position}==-1
-    list( APPEND LIST_ITK_IO_USED ${io} )
+foreach(io ${ALL_IO})
+  list(FIND ITK_MODULES_ENABLED ${io} position)
+  if(${position} GREATER -1) #not found: ${position}==-1
+    list(APPEND LIST_ITK_IO_USED ${io})
   endif()
 endforeach()
 
@@ -50,12 +62,12 @@ set(ITKComponents
   )
 find_package(ITK COMPONENTS ${ITKComponents} REQUIRED )
 include(${ITK_USE_FILE})
-if( ${ITK_VERSION_MAJOR} VERSION_LESS 4)
-  message(FATAL_ERROR "ITKv4 is necessary to compile this tool")
+if(${ITK_VERSION_MAJOR} VERSION_LESS 4)
+  message(FATAL_ERROR "ITKv4 is required to compile this tool")
 endif()
-set (MODULE_NAME ResampleDTIlogEuclidean)
 
-Set( dtiProcessFiles
+#-----------------------------------------------------------------------------
+set(MODULE_SRCS
   dtiprocessFiles/deformationfieldio.h
   dtiprocessFiles/deformationfieldio.cxx
   dtiprocessFiles/itkHFieldToDeformationFieldImageFilter.h
@@ -64,20 +76,27 @@ Set( dtiProcessFiles
   dtiprocessFiles/itkDeformationFieldToHFieldImageFilter.txx
   )
 
+set(MODULE_TARGET_LIBRARIES
+  ${ITK_LIBRARIES}
+  )
+
+#-----------------------------------------------------------------------------
 option(STATIC_RESAMPLEDTI "Build static ResampleDTIlogEuclidean" ON)
-
-
-if( ${STATIC_RESAMPLEDTI} )
-  set( STATIC "EXECUTABLE_ONLY" )
+if(${STATIC_RESAMPLEDTI})
+  set(STATIC "EXECUTABLE_ONLY")
 endif()
 
+#-----------------------------------------------------------------------------
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   ${STATIC}
-  ADDITIONAL_SRCS ${dtiProcessFiles}
-  TARGET_LIBRARIES ${ITK_LIBRARIES}
+  ADDITIONAL_SRCS ${MODULE_SRCS}
+  TARGET_LIBRARIES ${MODULE_TARGET_LIBRARIES}
   )
+
 export(TARGETS ${MODULE_NAME} FILE ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}-exports.cmake)
+
+#-----------------------------------------------------------------------------
 option(BUILD_TESTING "Build Testing" ON)
 if(BUILD_TESTING)
   add_subdirectory(Testing)

--- a/Source/ResampleDTIlogEuclidean.cxx
+++ b/Source/ResampleDTIlogEuclidean.cxx
@@ -797,7 +797,7 @@ int Do( parameters list )
   typedef typename WriterType::Pointer           WriterTypePointer;
   WriterTypePointer         writer = WriterType::New();
   itk::Matrix<double, 3, 3> measurementFrame;
-  bool hasMeasurementFrame ;
+  bool hasMeasurementFrame = false;
   try
   {
     typedef itk::DiffusionTensor3DRead< PixelType > ReaderType ;

--- a/Source/ResampleDTIlogEuclidean.cxx
+++ b/Source/ResampleDTIlogEuclidean.cxx
@@ -432,10 +432,8 @@ SetTransformAndOrder( parameters & list,
                       const itk::Point<double> & outputImageCenter
                       )
 {
-  typedef itk::DiffusionTensor3DTransform<PixelType> TransformType;
   typedef itk::DiffusionTensor3DNonRigidTransform<PixelType>
     NonRigidTransformType;
-  typedef typename TransformType::Pointer                 TransformTypePointer;
   typedef itk::DiffusionTensor3DRigidTransform<PixelType> RigidTransformType;
   typedef itk::DiffusionTensor3DFSAffineTransform<PixelType>
     FSAffineTransformType;

--- a/Source/ResampleDTIlogEuclidean.cxx
+++ b/Source/ResampleDTIlogEuclidean.cxx
@@ -347,7 +347,7 @@ ComputeTransformMatrix( const parameters & list,
 
 template <class PixelType>
 typename itk::DiffusionTensor3DAffineTransform<PixelType>::Pointer
-FSOrPPD( const std::string & ppd, itk::Matrix<double, 4, 4> *matrix = NULL )
+FSOrPPD( const std::string & ppd, itk::Matrix<double, 4, 4> *matrix = nullptr )
 {
   typedef itk::DiffusionTensor3DFSAffineTransform<PixelType>
     FSAffineTransformType;
@@ -492,7 +492,7 @@ SetTransformAndOrder( parameters & list,
             {
             std::cerr << "Transformation type not yet implemented for tensors"
                       << std::endl;
-            return NULL;
+            return nullptr;
             }
           }
         }
@@ -504,7 +504,7 @@ SetTransformAndOrder( parameters & list,
         {
         std::cerr << "Error in the file containing the transformation"
                   << std::endl;
-        return NULL;
+        return nullptr;
         }
       }
     }

--- a/Source/ResampleDTIlogEuclidean.cxx
+++ b/Source/ResampleDTIlogEuclidean.cxx
@@ -1061,7 +1061,7 @@ int Do( parameters list )
       }
     logFilter->Update();
     image = logFilter->GetOutput();
-    defaultPixelValue = vcl_log( defaultPixelValue );
+    defaultPixelValue = std::log( defaultPixelValue );
     }
   // start transform
     {                                                 // local for memory management: the input image should not stay in

--- a/Source/Testing/CMakeLists.txt
+++ b/Source/Testing/CMakeLists.txt
@@ -14,6 +14,10 @@ set(TransformedImage ${TEMP_DIR}/dt-helix-transformed.nrrd)
 set(OriginalImage DATA{${ExternalData_DIRECTORY}/dt-helix.nrrd})
 
 #-----------------------------------------------------------------------------
+configure_file(
+  itkTestMainExtendedConfigure.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/itkTestMainExtendedConfigure.h
+  )
 add_executable(${CLP}Test ${CLP}Test.cxx)
 target_link_libraries(${CLP}Test ${CLP}Lib ${SlicerExecutionModel_EXTRA_EXECUTABLE_TARGET_LIBRARIES})
 set_target_properties(${CLP}Test PROPERTIES LABELS ${CLP})

--- a/Source/Testing/CMakeLists.txt
+++ b/Source/Testing/CMakeLists.txt
@@ -73,6 +73,7 @@ ExternalData_add_test(${CLP}Data NAME ${CLP}BSplineWSInterpolationTest COMMAND $
     ${ReferenceImageBSplineWS}
     ${TransformedImage3}
   --compareIntensityTolerance 0
+  --compareNumberOfPixelsTolerance 1
   ModuleEntryPoint
     -f ${BSplineFile}
     --interpolation ws
@@ -92,6 +93,7 @@ ExternalData_add_test(${CLP}Data NAME ${CLP}BSplineInterpolationTest COMMAND ${S
     ${ReferenceImageBSplineInterpolation}
     ${TransformedImage4}
   --compareIntensityTolerance 0
+  --compareNumberOfPixelsTolerance 1
   ModuleEntryPoint
     -f ${AffineFile}
     --interpolation bs
@@ -129,6 +131,7 @@ ExternalData_add_test(${CLP}Data NAME ${CLP}LogTest COMMAND ${SEM_LAUNCH_COMMAND
     ${ReferenceImageLog}
     ${TransformedImage7}
   --compareIntensityTolerance 0
+  --compareNumberOfPixelsTolerance 1
   ModuleEntryPoint
     -f ${AffineFile}
     ${OriginalImage}

--- a/Source/Testing/CMakeLists.txt
+++ b/Source/Testing/CMakeLists.txt
@@ -1,31 +1,27 @@
-#
-# Test executable
-#
 
 
 # Add standard remote object stores to user's
 # configuration.
 list(APPEND ExternalData_URL_TEMPLATES
-"http://slicer.kitware.com/midas3/api/rest?method=midas.bitstream.download&checksum=%(hash)"
-)
+  "http://slicer.kitware.com/midas3/api/rest?method=midas.bitstream.download&checksum=%(hash)"
+  )
 
-
-
-# ResampleDTI tests
-set(ExternalData_DIRECTORY TestData )
-set(SOURCE_DIRECTORY ${ResampleDTIlogEuclidean_SOURCE_DIR}/Source/Testing/TestData )
+#-----------------------------------------------------------------------------
+set(ExternalData_DIRECTORY TestData)
+set(SOURCE_DIRECTORY ${ResampleDTIlogEuclidean_SOURCE_DIR}/Source/Testing/TestData)
 set(TEMP_DIR ${ResampleDTIlogEuclidean_BINARY_DIR}/Testing/Temporary )
+set(TransformedImage ${TEMP_DIR}/dt-helix-transformed.nrrd)
+set(OriginalImage DATA{${ExternalData_DIRECTORY}/dt-helix.nrrd})
 
-set(TransformedImage ${TEMP_DIR}/dt-helix-transformed.nrrd )
-set(OriginalImage DATA{${ExternalData_DIRECTORY}/dt-helix.nrrd} )
-
+#-----------------------------------------------------------------------------
 add_executable(${CLP}Test ${CLP}Test.cxx)
 target_link_libraries(${CLP}Test ${CLP}Lib ${SlicerExecutionModel_EXTRA_EXECUTABLE_TARGET_LIBRARIES})
 set_target_properties(${CLP}Test PROPERTIES LABELS ${CLP})
 #set_target_properties(${CLP}Test PROPERTIES FOLDER ${${CLP}_TARGETS_FOLDER})
 
-set(TransformFile ${SOURCE_DIRECTORY}/rotation.tfm )
-set(TransformedImage1 ${TEMP_DIR}/dt-helix-transformed1.nrrd )
+#-----------------------------------------------------------------------------
+set(TransformFile ${SOURCE_DIRECTORY}/rotation.tfm)
+set(TransformedImage1 ${TEMP_DIR}/dt-helix-transformed1.nrrd)
 set(ReferenceImageRotationNN DATA{${ExternalData_DIRECTORY}/dt-helix-ref-Rotated.nrrd})
 ExternalData_add_test(${CLP}Data NAME ${CLP}RotationNNTest COMMAND ${SEM_LAUNCH_COMMAND} $<TARGET_FILE:${CLP}Test>
   --compare
@@ -43,9 +39,10 @@ ExternalData_add_test(${CLP}Data NAME ${CLP}RotationNNTest COMMAND ${SEM_LAUNCH_
     --nolog
   )
 
-set(TransformedImage2 ${TEMP_DIR}/dt-helix-transformed2.nrrd )
+#-----------------------------------------------------------------------------
+set(TransformedImage2 ${TEMP_DIR}/dt-helix-transformed2.nrrd)
 set(ReferenceImageRotationAndAffine DATA{${ExternalData_DIRECTORY}/dt-helix-ref-RotationAndAffine.nrrd})
-set(RotationAndAffineFile ${SOURCE_DIRECTORY}/rotationAndAffine.tfm )
+set(RotationAndAffineFile ${SOURCE_DIRECTORY}/rotationAndAffine.tfm)
 ExternalData_add_test(${CLP}Data NAME ${CLP}2RigidTransformsLinearTest COMMAND ${SEM_LAUNCH_COMMAND} $<TARGET_FILE:${CLP}Test>
   --compare
     ${ReferenceImageRotationAndAffine}
@@ -63,7 +60,8 @@ ExternalData_add_test(${CLP}Data NAME ${CLP}2RigidTransformsLinearTest COMMAND $
     --nolog
   )
 
-set(TransformedImage3 ${TEMP_DIR}/dt-helix-transformed3.nrrd )
+#-----------------------------------------------------------------------------
+set(TransformedImage3 ${TEMP_DIR}/dt-helix-transformed3.nrrd)
 set(ReferenceImageBSplineWS DATA{${ExternalData_DIRECTORY}/dt-helix-ref-BS.nrrd})
 set(BSplineFile ${SOURCE_DIRECTORY}/FastNonrigidBSplineregistrationTransform.tfm)
 ExternalData_add_test(${CLP}Data NAME ${CLP}BSplineWSInterpolationTest COMMAND ${SEM_LAUNCH_COMMAND} $<TARGET_FILE:${CLP}Test>
@@ -81,7 +79,8 @@ ExternalData_add_test(${CLP}Data NAME ${CLP}BSplineWSInterpolationTest COMMAND $
     --nolog
   )
 
-set(TransformedImage4 ${TEMP_DIR}/dt-helix-transformed4.nrrd )
+#-----------------------------------------------------------------------------
+set(TransformedImage4 ${TEMP_DIR}/dt-helix-transformed4.nrrd)
 set(ReferenceImageBSplineInterpolation DATA{${ExternalData_DIRECTORY}/dt-helix-ref-BSInterpolation.nrrd})
 set(AffineFile ${SOURCE_DIRECTORY}/affine.tfm)
 ExternalData_add_test(${CLP}Data NAME ${CLP}BSplineInterpolationTest COMMAND ${SEM_LAUNCH_COMMAND} $<TARGET_FILE:${CLP}Test>
@@ -99,7 +98,8 @@ ExternalData_add_test(${CLP}Data NAME ${CLP}BSplineInterpolationTest COMMAND ${S
     --nolog
   )
 
-set(TransformedImage5 ${TEMP_DIR}/dt-helix-transformed5.nrrd )
+#-----------------------------------------------------------------------------
+set(TransformedImage5 ${TEMP_DIR}/dt-helix-transformed5.nrrd)
 set(ReferenceImageHField DATA{${ExternalData_DIRECTORY}/dt-helix-ref-HField.nrrd})
 set(HFieldFile DATA{${ExternalData_DIRECTORY}/deformationField.nrrd})
 ExternalData_add_test(${CLP}Data NAME ${CLP}HFieldTest COMMAND ${SEM_LAUNCH_COMMAND} $<TARGET_FILE:${CLP}Test>
@@ -116,7 +116,8 @@ ExternalData_add_test(${CLP}Data NAME ${CLP}HFieldTest COMMAND ${SEM_LAUNCH_COMM
     --nolog
   )
 
-set(TransformedImage7 ${TEMP_DIR}/dt-helix-transformed7.nrrd )
+#-----------------------------------------------------------------------------
+set(TransformedImage7 ${TEMP_DIR}/dt-helix-transformed7.nrrd)
 set(ReferenceImageLog DATA{${ExternalData_DIRECTORY}/dt-helix-ref-Log.nrrd})
 set(AffineFile ${SOURCE_DIRECTORY}/affine.tfm)
 ExternalData_add_test(${CLP}Data NAME ${CLP}LogTest COMMAND ${SEM_LAUNCH_COMMAND} $<TARGET_FILE:${CLP}Test>
@@ -130,11 +131,10 @@ ExternalData_add_test(${CLP}Data NAME ${CLP}LogTest COMMAND ${SEM_LAUNCH_COMMAND
     ${TransformedImage7}
   )
 
-
-
+#-----------------------------------------------------------------------------
 #Test itkTestMainExtended.h
 #copy scalar file to binary directory
-set(SourceScalarFile DATA{${ExternalData_DIRECTORY}/AddTest_DOUBLE.mha} )
+set(SourceScalarFile DATA{${ExternalData_DIRECTORY}/AddTest_DOUBLE.mha})
 
 ExternalData_add_test(${CLP}Data NAME itkTestMainExtendedScalarTest COMMAND ${SEM_LAUNCH_COMMAND} $<TARGET_FILE:${CLP}Test>
  --compare
@@ -146,7 +146,8 @@ ExternalData_add_test(${CLP}Data NAME itkTestMainExtendedScalarTest COMMAND ${SE
     ${TransformedImage}
   )
 
-set(TransformedImage6 ${TEMP_DIR}/dt-helix-transformed6.nrrd )
+#-----------------------------------------------------------------------------
+set(TransformedImage6 ${TEMP_DIR}/dt-helix-transformed6.nrrd)
 ExternalData_add_test(${CLP}Data NAME itkTestMainExtendedFailedTest COMMAND ${SEM_LAUNCH_COMMAND} $<TARGET_FILE:${CLP}Test>
   --compare
     ${ReferenceImageHField}
@@ -157,14 +158,12 @@ ExternalData_add_test(${CLP}Data NAME itkTestMainExtendedFailedTest COMMAND ${SE
     ${OriginalImage}
     ${TransformedImage6}
   )
-set_tests_properties( itkTestMainExtendedFailedTest PROPERTIES WILL_FAIL true)
+set_tests_properties(itkTestMainExtendedFailedTest PROPERTIES WILL_FAIL true)
 
-
-
-
+#-----------------------------------------------------------------------------
 set(ReferenceConcatenatedDisplacementField DATA{${ExternalData_DIRECTORY}/ReferenceConcatenatedDisplacementField.nrrd})
-set(ConcatDisplacementField ${TEMP_DIR}/ConcatenatedDisplacementField.nrrd )
-set(DummyTransformedImage ${TEMP_DIR}/dt-helix-transformed8-dummy.nrrd )
+set(ConcatDisplacementField ${TEMP_DIR}/ConcatenatedDisplacementField.nrrd)
+set(DummyTransformedImage ${TEMP_DIR}/dt-helix-transformed8-dummy.nrrd)
 set(HFieldFile DATA{${ExternalData_DIRECTORY}/deformationField.nrrd})
 set(ScalarInput DATA{${ExternalData_DIRECTORY}/dt-helix-fa.nrrd})
 ExternalData_add_test(${CLP}Data NAME ${CLP}HFieldConcatOnlyTest COMMAND ${SEM_LAUNCH_COMMAND} $<TARGET_FILE:${CLP}Test>
@@ -183,6 +182,7 @@ ExternalData_add_test(${CLP}Data NAME ${CLP}HFieldConcatOnlyTest COMMAND ${SEM_L
     --outputDisplacementField ${ConcatDisplacementField}
   )
 
+#-----------------------------------------------------------------------------
 ExternalData_add_test(${CLP}Data NAME ${CLP}HFieldConcatFailedNoConcatenationOnlyTest COMMAND ${SEM_LAUNCH_COMMAND} $<TARGET_FILE:${CLP}>
     -H ${HFieldFile}
     ${ScalarInput}
@@ -194,6 +194,7 @@ ExternalData_add_test(${CLP}Data NAME ${CLP}HFieldConcatFailedNoConcatenationOnl
   )
 set_tests_properties(${CLP}HFieldConcatFailedNoConcatenationOnlyTest PROPERTIES WILL_FAIL true)
 
+#-----------------------------------------------------------------------------
 ExternalData_add_test(${CLP}Data NAME ${CLP}HFieldConcatFailedNoReferenceImageTest COMMAND ${SEM_LAUNCH_COMMAND} $<TARGET_FILE:${CLP}>
     -H ${HFieldFile}
     ${ScalarInput}

--- a/Source/Testing/itkDifferenceDiffusionTensor3DImageFilter.h
+++ b/Source/Testing/itkDifferenceDiffusionTensor3DImageFilter.h
@@ -129,8 +129,8 @@ protected:
 
   Array<AccumulateType>    m_ThreadDifferenceSum;
   Array<unsigned long>     m_ThreadNumberOfPixels;
-  MatrixType measurementFrameValid ;
-  MatrixType measurementFrameTest ;
+  MatrixType            m_MeasurementFrameValid;
+  MatrixType            m_MeasurementFrameTest;
 private:
    DifferenceDiffusionTensor3DImageFilter(const Self&); //purposely not implemented
   void operator=(const Self&); //purposely not implemented

--- a/Source/Testing/itkDifferenceDiffusionTensor3DImageFilter.h
+++ b/Source/Testing/itkDifferenceDiffusionTensor3DImageFilter.h
@@ -7,13 +7,13 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
-#ifndef __itkDifferenceDiffusionTensor3DImageFilter_h
-#define __itkDifferenceDiffusionTensor3DImageFilter_h
+#ifndef itkDifferenceDiffusionTensor3DImageFilter_h
+#define itkDifferenceDiffusionTensor3DImageFilter_h
 
 #include "itkImageToImageFilter.h"
 #include "itkDiffusionTensor3D.h"
@@ -24,7 +24,7 @@
 
 namespace itk
 {
-  
+
 /** \class DifferenceDiffusionTensor3DImageFilter
  * \brief Implements comparison between two DiffusionTensor3D images.
  *
@@ -35,13 +35,13 @@ namespace itk
  * neighborhood of the homologous pixel in the other image. At one voxel, it
  * adds the absolute value of the difference between the different components
  * of the diffusion tensor. It compares the sum to a threshold set by the
- * developper 
- * 
+ * developer
+ *
  * \ingroup IntensityImageFilters   Multithreaded
  */
 template <class TInputImage, class TOutputImage>
 class DifferenceDiffusionTensor3DImageFilter :
-    public ImageToImageFilter<TInputImage, TOutputImage> 
+    public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Standard class typedefs. */
@@ -64,44 +64,43 @@ public:
   typedef typename OutputImageType::RegionType                OutputImageRegionType;
   typedef typename NumericTraits<OutputPixelType>::RealType   RealType;
   typedef typename NumericTraits<RealType>::AccumulateType    AccumulateType;
- 
+
   typedef std::vector< std::vector< double > > DoubleVectorType ;
   typedef itk::MetaDataObject< DoubleVectorType > MetaDataDoubleVectorType ;
   typedef itk::Matrix< double , 3 , 3 > MatrixType ;
-  
-  
+
   /** Set the valid image input.  This will be input 0.  */
   virtual void SetValidInput(const InputImageType* validImage);
-  
+
   /** Set the test image input.  This will be input 1.  */
   virtual void SetTestInput(const InputImageType* testImage);
-  
+
   /** Set/Get the maximum distance away to look for a matching pixel.
       Default is 0. */
   itkSetMacro(ToleranceRadius, int);
   itkGetConstMacro(ToleranceRadius, int);
-  
+
   /** Set/Get the minimum threshold for pixels to be different.
       Default is 0. */
   itkSetMacro(DifferenceThreshold, OutputPixelType);
   itkGetConstMacro(DifferenceThreshold, OutputPixelType);
-  
+
   /** Set/Get ignore boundary pixels.  Useful when resampling may have
-   *    introduced difference pixel values along the image edge 
+   *    introduced difference pixel values along the image edge
    *    Default = false */
   itkSetMacro(IgnoreBoundaryPixels, bool);
   itkGetConstMacro(IgnoreBoundaryPixels, bool);
-  
+
   /** Get parameters of the difference image after execution.  */
   itkGetConstMacro(MeanDifference, RealType);
   itkGetConstMacro(TotalDifference, AccumulateType);
   itkGetConstMacro(NumberOfPixelsWithDifferences, unsigned long);
-  
 protected:
    MatrixType GetMetaDataDictionary( const InputImageType* image ) ;
+
    DifferenceDiffusionTensor3DImageFilter();
    virtual ~DifferenceDiffusionTensor3DImageFilter() {}
-  
+
   void PrintSelf(std::ostream& os, Indent indent) const;
 
   /** DifferenceImageFilter can be implemented as a multithreaded
@@ -121,6 +120,7 @@ protected:
   void BeforeThreadedGenerateData();
   void AfterThreadedGenerateData();
   InputPixelType ApplyMeasurementFrameToTensor( InputPixelType tensor , const MatrixType &measurementFrame ) ;
+
   OutputPixelType          m_DifferenceThreshold;
   RealType                 m_MeanDifference;
   AccumulateType           m_TotalDifference;

--- a/Source/Testing/itkDifferenceDiffusionTensor3DImageFilter.h
+++ b/Source/Testing/itkDifferenceDiffusionTensor3DImageFilter.h
@@ -99,9 +99,10 @@ protected:
    MatrixType GetMetaDataDictionary( const InputImageType* image ) ;
 
    DifferenceDiffusionTensor3DImageFilter();
-   virtual ~DifferenceDiffusionTensor3DImageFilter() {}
+  ~DifferenceDiffusionTensor3DImageFilter() override
+   = default;
 
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /** DifferenceImageFilter can be implemented as a multithreaded
    * filter.  Therefore, this implementation provides a
@@ -114,11 +115,12 @@ protected:
    *
    * \sa ImageToImageFilter::ThreadedGenerateData(),
    *     ImageToImageFilter::GenerateData()  */
-  void ThreadedGenerateData(const OutputImageRegionType& threadRegion,
-                            ThreadIdType threadId);
+  void ThreadedGenerateData(const OutputImageRegionType& threadRegion, ThreadIdType threadId) override;
 
-  void BeforeThreadedGenerateData();
-  void AfterThreadedGenerateData();
+  void BeforeThreadedGenerateData() override;
+
+  void AfterThreadedGenerateData() override;
+
   InputPixelType ApplyMeasurementFrameToTensor( InputPixelType tensor , const MatrixType &measurementFrame ) ;
 
   OutputPixelType          m_DifferenceThreshold;
@@ -132,8 +134,8 @@ protected:
   MatrixType            m_MeasurementFrameValid;
   MatrixType            m_MeasurementFrameTest;
 private:
-   DifferenceDiffusionTensor3DImageFilter(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
+  DifferenceDiffusionTensor3DImageFilter(const Self &) = delete;
+  void operator=(const Self &) = delete;
 
   bool m_IgnoreBoundaryPixels;
 };

--- a/Source/Testing/itkDifferenceDiffusionTensor3DImageFilter.txx
+++ b/Source/Testing/itkDifferenceDiffusionTensor3DImageFilter.txx
@@ -49,6 +49,14 @@ DifferenceDiffusionTensor3DImageFilter<TInputImage, TOutputImage>
   m_IgnoreBoundaryPixels = false;
   m_MeasurementFrameValid.SetIdentity();
   m_MeasurementFrameTest.SetIdentity();
+
+  // Keep using the ITKv4 threading system.
+  // This class could be updated to use the ITKv5 dynamic threading system in the future
+  // Check the ITK migration guide:
+  // https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/ITK5MigrationGuide.md
+  // This class in particular does use threadId, so a more complex solution is needed
+  // Check the example of using std::atomic in the migration guide.
+  this->DynamicMultiThreadingOff();
 }
 
 // ----------------------------------------------------------------------------

--- a/Source/Testing/itkDifferenceDiffusionTensor3DImageFilter.txx
+++ b/Source/Testing/itkDifferenceDiffusionTensor3DImageFilter.txx
@@ -47,8 +47,8 @@ DifferenceDiffusionTensor3DImageFilter<TInputImage, TOutputImage>
   m_TotalDifference = NumericTraits<AccumulateType>::ZeroValue();
   m_NumberOfPixelsWithDifferences = 0;
   m_IgnoreBoundaryPixels = false;
-  measurementFrameValid.SetIdentity();
-  measurementFrameTest.SetIdentity();
+  m_MeasurementFrameValid.SetIdentity();
+  m_MeasurementFrameTest.SetIdentity();
 }
 
 // ----------------------------------------------------------------------------
@@ -139,8 +139,8 @@ DifferenceDiffusionTensor3DImageFilter<TInputImage, TOutputImage>
   m_ThreadDifferenceSum.Fill(NumericTraits<AccumulateType>::ZeroValue());
   m_ThreadNumberOfPixels.Fill(0);
 
-  measurementFrameValid = GetMetaDataDictionary( this->GetInput(0) );
-  measurementFrameTest = GetMetaDataDictionary( this->GetInput(1) );
+  m_MeasurementFrameValid = GetMetaDataDictionary( this->GetInput(0) );
+  m_MeasurementFrameTest = GetMetaDataDictionary( this->GetInput(1) );
 
 }
 
@@ -229,13 +229,13 @@ DifferenceDiffusionTensor3DImageFilter<TInputImage, TOutputImage>
         {
         // Get the current valid pixel.
 
-        InputPixelType t = ApplyMeasurementFrameToTensor( valid.Get(), measurementFrameValid );
+        InputPixelType t = ApplyMeasurementFrameToTensor( valid.Get(), m_MeasurementFrameValid );
 
         //  Assume a good match - so test center pixel first, for speed
         typename InputPixelType::Iterator it;
         typename InputPixelType::Iterator ittest;
         RealType       sumdifference = NumericTraits<RealType>::ZeroValue();
-        InputPixelType centerTensor = ApplyMeasurementFrameToTensor( test.GetCenterPixel(), measurementFrameTest );
+        InputPixelType centerTensor = ApplyMeasurementFrameToTensor( test.GetCenterPixel(), m_MeasurementFrameTest );
         for( it = t.Begin(), ittest = centerTensor.Begin(); it != t.End(); ++it, ++ittest )
           {
           RealType difference = static_cast<RealType>( (*it) ) - (*ittest);
@@ -257,7 +257,7 @@ DifferenceDiffusionTensor3DImageFilter<TInputImage, TOutputImage>
             // Use the RealType for the difference to make sure we get the
             // sign.
             sumdifference = NumericTraits<RealType>::ZeroValue();
-            InputPixelType tensor = ApplyMeasurementFrameToTensor( test.GetPixel(i), measurementFrameTest );
+            InputPixelType tensor = ApplyMeasurementFrameToTensor( test.GetPixel(i), m_MeasurementFrameTest );
             for( it = t.Begin(), ittest = tensor.Begin(); it != t.End(); ++it, ++ittest )
               {
               RealType difference = static_cast<RealType>( *it ) - (*ittest);

--- a/Source/Testing/itkDifferenceDiffusionTensor3DImageFilter.txx
+++ b/Source/Testing/itkDifferenceDiffusionTensor3DImageFilter.txx
@@ -12,8 +12,8 @@
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
-#ifndef __itkDifferenceDiffusionTensor3DImageFilter_txx
-#define __itkDifferenceDiffusionTensor3DImageFilter_txx
+#ifndef itkDifferenceDiffusionTensor3DImageFilter_txx
+#define itkDifferenceDiffusionTensor3DImageFilter_txx
 
 #include "itkDifferenceDiffusionTensor3DImageFilter.h"
 
@@ -180,8 +180,10 @@ DifferenceDiffusionTensor3DImageFilter<TInputImage, TOutputImage>
   typedef ConstNeighborhoodIterator<InputImageType> SmartIterator;
   typedef ImageRegionConstIterator<InputImageType>  InputIterator;
   typedef ImageRegionIterator<OutputImageType>      OutputIterator;
+
   typedef NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>
   FacesCalculator;
+
   typedef typename FacesCalculator::RadiusType   RadiusType;
   typedef typename FacesCalculator::FaceListType FaceListType;
   typedef typename FaceListType::iterator        FaceListIterator;

--- a/Source/Testing/itkTestMainExtended.h
+++ b/Source/Testing/itkTestMainExtended.h
@@ -25,8 +25,8 @@
  *  please refer to the NOTICE file at the top of the ITK source tree.
  *
  *=========================================================================*/
-#ifndef __itkTestMainDTI_h
-#define __itkTestMainDTI_h
+#ifndef itkTestMainExtended_h
+#define itkTestMainExtended_h
 
 // This file is used to create TestDriver executables
 // These executables are able to register a function pointer to a string name

--- a/Source/Testing/itkTestMainExtended.h
+++ b/Source/Testing/itkTestMainExtended.h
@@ -54,6 +54,7 @@
 #include "itkIntTypes.h"
 #include "itkFloatingPointExceptions.h"
 #include <itkTensorFractionalAnisotropyImageFilter.h>
+#include "itkPluginUtilities.h"
 
 #define ITK_TEST_DIMENSION_MAX 6
 
@@ -252,20 +253,6 @@ int main(int ac, char *av[])
 
 // Regression Testing Code
 
-//What pixeltype is the image 
-void GetImageType( const char* fileName ,
-                   itk::ImageIOBase::IOPixelType &pixelType ,
-                   itk::ImageIOBase::IOComponentType &componentType )
-{
-   typedef itk::Image< unsigned char , 3 > ImageType ;
-   itk::ImageFileReader< ImageType >::Pointer imageReader =
-         itk::ImageFileReader< ImageType >::New();
-   imageReader->SetFileName( fileName ) ;
-   imageReader->UpdateOutputInformation() ;
-   pixelType = imageReader->GetImageIO()->GetPixelType() ;
-   componentType = imageReader->GetImageIO()->GetComponentType() ;
-}
-
 template< class ImageType >
 int ReadImages(  const char* baselineImageFilename ,
                  const char* testImageFilename ,
@@ -319,8 +306,6 @@ testImage = testReader->GetOutput() ;
 return 0 ;
 }
 
-
-
 int RegressionTestImage(const char *testImageFilename,
                         const char *baselineImageFilename,
                         int reportErrors,
@@ -328,20 +313,18 @@ int RegressionTestImage(const char *testImageFilename,
                         ::itk::SizeValueType numberOfPixelsTolerance,
                         unsigned int radiusTolerance)
 {
-  // Use the factory mechanism to read the test and baseline files and convert
-  // them to double
+  // Use the factory mechanism to read the test and baseline files and convert them to double
   typedef itk::Image<double, ITK_TEST_DIMENSION_MAX>        ImageType;
   typedef itk::Image<itk::DiffusionTensor3D<double>,ITK_TEST_DIMENSION_MAX>        DiffusionImageType;
   typedef itk::Image<unsigned char, ITK_TEST_DIMENSION_MAX> OutputType;
   typedef itk::Image<unsigned char, 2>                      DiffOutputType;
 
-
- itk::ImageIOBase::IOPixelType pixelTypeBaseline ;
+  itk::ImageIOBase::IOPixelType pixelTypeBaseline ;
   itk::ImageIOBase::IOComponentType componentTypeBaseline ;
-  GetImageType( baselineImageFilename , pixelTypeBaseline , componentTypeBaseline ) ;
+  itk::GetImageType( baselineImageFilename , pixelTypeBaseline , componentTypeBaseline ) ;
   itk::ImageIOBase::IOPixelType pixelTypeTestImage ;
   itk::ImageIOBase::IOComponentType componentTypeTestImage ;
-  GetImageType( testImageFilename , pixelTypeTestImage , componentTypeTestImage ) ;
+  itk::GetImageType( testImageFilename , pixelTypeTestImage , componentTypeTestImage ) ;
   bool diffusion = false ;
   //check if the voxels of the image are diffusion tensors
   if( ( pixelTypeBaseline == itk::ImageIOBase::SYMMETRICSECONDRANKTENSOR
@@ -383,6 +366,7 @@ int RegressionTestImage(const char *testImageFilename,
       diff->SetDifferenceThreshold( intensityTolerance );
       diff->SetToleranceRadius( radiusTolerance );
       diff->UpdateLargestPossibleRegion();
+
       status = diff->GetNumberOfPixelsWithDifferences();
 
   }
@@ -407,7 +391,7 @@ int RegressionTestImage(const char *testImageFilename,
      status = diffusiondiff->GetNumberOfPixelsWithDifferences();
   }
 
-  // if there are discrepencies, create an diff image
+  // if there are discrepancies, create an diff image
   if( ( status > numberOfPixelsTolerance ) && reportErrors )
     {
     typedef itk::RescaleIntensityImageFilter<ImageType, OutputType> RescaleType;
@@ -568,7 +552,7 @@ int RegressionTestImage(const char *testImageFilename,
     std::cout << baseName.str();
     std::cout << "</DartMeasurementFile>" << std::endl;
 
-    std::ostringstream testName;
+    ::std::ostringstream testName;
     if( !diffusion )
     {
       testName << testImageFilename << ".test.png";

--- a/Source/Testing/itkTestMainExtended.h
+++ b/Source/Testing/itkTestMainExtended.h
@@ -56,6 +56,11 @@
 #include <itkTensorFractionalAnisotropyImageFilter.h>
 #include "itkPluginUtilities.h"
 
+#include "itkTestMainExtendedConfigure.h" // For ResampleDTIlogEuclidean_BUILD_SLICER_EXTENSION
+#ifdef ResampleDTIlogEuclidean_BUILD_SLICER_EXTENSION
+#include <itkFactoryRegistration.h>
+#endif
+
 #define ITK_TEST_DIMENSION_MAX 6
 
 typedef int ( *MainFuncPointer )(int, char *[]);
@@ -99,6 +104,10 @@ int main(int ac, char *av[])
 
   typedef std::pair<char *, char *> ComparePairType;
   std::vector<ComparePairType> compareList;
+
+#ifdef ResampleDTIlogEuclidean_BUILD_SLICER_EXTENSION
+  itk::itkFactoryRegistration();
+#endif
 
   RegisterTests();
   std::string testToRun;

--- a/Source/Testing/itkTestMainExtendedConfigure.h.in
+++ b/Source/Testing/itkTestMainExtendedConfigure.h.in
@@ -1,0 +1,6 @@
+#ifndef itkTestMainExtendedConfigure_h
+#define itkTestMainExtendedConfigure_h
+
+#cmakedefine ResampleDTIlogEuclidean_BUILD_SLICER_EXTENSION
+
+#endif

--- a/Source/dtiprocessFiles/itkHFieldToDeformationFieldImageFilter.h
+++ b/Source/dtiprocessFiles/itkHFieldToDeformationFieldImageFilter.h
@@ -68,27 +68,25 @@ public:
   itkNewMacro(Self);
 
   /** Print internal ivars */
-  void PrintSelf(std::ostream& os, Indent indent) const
+  void PrintSelf(std::ostream& os, Indent indent) const override
   {
     this->Superclass::PrintSelf( os, indent );
   }
 
   // need to override GenerateData (This should be threaded)
-  void GenerateData();
+  void GenerateData() override;
 
   OutputPixelType ComputeDisplacement(typename InputImageType::ConstPointer input,
                                       typename InputImageType::IndexType ind,
                                       typename InputImageType::PixelType hvec);
 protected:
   HFieldToDeformationFieldImageFilter()
-  {
-  };
-  virtual ~HFieldToDeformationFieldImageFilter()
-  {
-  };
+   = default;
+  ~HFieldToDeformationFieldImageFilter() override
+   = default;
 private:
-  HFieldToDeformationFieldImageFilter(const Self &); // purposely not implemented
-  void operator=(const Self &);                      // purposely not implemented
+  HFieldToDeformationFieldImageFilter(const Self &) = delete;
+  void operator=(const Self &) = delete;
 
 };
 

--- a/Source/dtiprocessFiles/itkHFieldToDeformationFieldImageFilter.h
+++ b/Source/dtiprocessFiles/itkHFieldToDeformationFieldImageFilter.h
@@ -16,8 +16,8 @@
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
-#ifndef __itkHFieldToDeformationFieldImageFilter_h
-#define __itkHFieldToDeformationFieldImageFilter_h
+#ifndef itkHFieldToDeformationFieldImageFilter_h
+#define itkHFieldToDeformationFieldImageFilter_h
 
 #include <itkImageToImageFilter.h>
 
@@ -30,7 +30,7 @@ namespace itk
 /** \class HFieldToDeformationFieldImageFilter
  * \brief Computes the Mean Diffusivity for every pixel of a input tensor image.
  *
- * HFieldToDeformationFieldImageFilter applies pixel-wise the invokation for
+ * HFieldToDeformationFieldImageFilter applies pixel-wise the invocation for
  * computing the mean diffusivity of every pixel. The pixel type of the
  * input image is expected to implement a method GetTrace(), and
  * to specify its return type as RealValueType.

--- a/Source/dtiprocessFiles/itkHFieldToDeformationFieldImageFilter.txx
+++ b/Source/dtiprocessFiles/itkHFieldToDeformationFieldImageFilter.txx
@@ -17,6 +17,9 @@
 
 =========================================================================*/
 
+#ifndef itkHFieldToDeformationFieldImageFilter_txx
+#define itkHFieldToDeformationFieldImageFilter_txx
+
 #include <itkImageRegionConstIteratorWithIndex.h>
 #include <itkImageRegionIterator.h>
 
@@ -84,3 +87,5 @@ HFieldToDeformationFieldImageFilter<TInputImage, TOutputImage>::ComputeDisplacem
 }
 
 } // namespace itk
+
+#endif

--- a/Source/itkDiffusionTensor3DAbsCorrection.h
+++ b/Source/itkDiffusionTensor3DAbsCorrection.h
@@ -129,7 +129,7 @@ protected:
   DiffusionTensor3DAbsCorrectionFilter()
   {
   }
-  virtual ~DiffusionTensor3DAbsCorrectionFilter()
+  ~DiffusionTensor3DAbsCorrectionFilter() override
   {
   }
 private:

--- a/Source/itkDiffusionTensor3DAbsCorrection.h
+++ b/Source/itkDiffusionTensor3DAbsCorrection.h
@@ -108,6 +108,9 @@ public:
   typedef SmartPointer<Self>       Pointer;
   typedef SmartPointer<const Self> ConstPointer;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DAbsCorrectionFilter, UnaryFunctorImageFilter);
+
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
 

--- a/Source/itkDiffusionTensor3DAbsCorrection.h
+++ b/Source/itkDiffusionTensor3DAbsCorrection.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DAbsCorrection.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2014-03-02 19:08:33 -0500 (Sun, 02 Mar 2014) $
-  Version:   $Revision: 22915 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DAbsCorrectionFilter_h
-#define __itkDiffusionTensor3DAbsCorrectionFilter_h
+#ifndef itkDiffusionTensor3DAbsCorrection_h
+#define itkDiffusionTensor3DAbsCorrection_h
 
 #include "itkUnaryFunctorImageFilter.h"
 #include "vnl/vnl_math.h"

--- a/Source/itkDiffusionTensor3DAffineTransform.h
+++ b/Source/itkDiffusionTensor3DAffineTransform.h
@@ -45,6 +45,10 @@ public:
   typedef MatrixExtended<double, 4, 4>                     MatrixTransform4x4Type;
   typedef AffineTransform<double, 3>                       AffineTransformType;
   typedef typename Superclass::VectorType                  VectorType;
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DAffineTransform, DiffusionTensor3DMatrix3x3Transform);
+
   /** Set the transformation matrix from an itk::AffineTransform< double , 3 > object
   */
   void SetTransform( typename AffineTransformType::Pointer transform );

--- a/Source/itkDiffusionTensor3DAffineTransform.h
+++ b/Source/itkDiffusionTensor3DAffineTransform.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DAffineTransform.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DAffineTransform_h
-#define __itkDiffusionTensor3DAffineTransform_h
+#ifndef itkDiffusionTensor3DAffineTransform_h
+#define itkDiffusionTensor3DAffineTransform_h
 
 #include "itkDiffusionTensor3DMatrix3x3Transform.h"
 #include <itkAffineTransform.h>

--- a/Source/itkDiffusionTensor3DAffineTransform.txx
+++ b/Source/itkDiffusionTensor3DAffineTransform.txx
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DAffineTransform.txx $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DAffineTransform_txx
-#define __itkDiffusionTensor3DAffineTransform_txx
+#ifndef itkDiffusionTensor3DAffineTransform_txx
+#define itkDiffusionTensor3DAffineTransform_txx
 
 #include "itkDiffusionTensor3DAffineTransform.h"
 

--- a/Source/itkDiffusionTensor3DBSplineInterpolateImageFunction.h
+++ b/Source/itkDiffusionTensor3DBSplineInterpolateImageFunction.h
@@ -39,6 +39,9 @@ public:
   typedef BSplineInterpolateImageFunction<ImageType, TCoordRep, double>
   BSplineInterpolateFunction;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DBSplineInterpolateImageFunction, DiffusionTensor3DInterpolateImageFunctionReimplementation);
+
   itkNewMacro( Self );
   // /Get the Spline Order, supports 0th - 5th order splines. The default is a 1st order spline.
   itkGetMacro( SplineOrder, int );

--- a/Source/itkDiffusionTensor3DBSplineInterpolateImageFunction.h
+++ b/Source/itkDiffusionTensor3DBSplineInterpolateImageFunction.h
@@ -48,7 +48,7 @@ public:
   // /Set the Spline Order, supports 0th - 5th order splines. The default is a 1st order spline.
   itkSetMacro( SplineOrder, unsigned int );
 protected:
-  void AllocateInterpolator();
+  void AllocateInterpolator() override;
 
   DiffusionTensor3DBSplineInterpolateImageFunction();
   unsigned int m_SplineOrder;

--- a/Source/itkDiffusionTensor3DBSplineInterpolateImageFunction.h
+++ b/Source/itkDiffusionTensor3DBSplineInterpolateImageFunction.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DBSplineInterpolateImageFunction.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DBSplineInterpolateImageFunction_h
-#define __itkDiffusionTensor3DBSplineInterpolateImageFunction_h
+#ifndef itkDiffusionTensor3DBSplineInterpolateImageFunction_h
+#define itkDiffusionTensor3DBSplineInterpolateImageFunction_h
 
 #include "itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h"
 #include <itkBSplineInterpolateImageFunction.h>

--- a/Source/itkDiffusionTensor3DBSplineInterpolateImageFunction.txx
+++ b/Source/itkDiffusionTensor3DBSplineInterpolateImageFunction.txx
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DBSplineInterpolateImageFunction.txx $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DBSplineInterpolateImageFunction_txx
-#define __itkDiffusionTensor3DBSplineInterpolateImageFunction_txx
+#ifndef itkDiffusionTensor3DBSplineInterpolateImageFunction_txx
+#define itkDiffusionTensor3DBSplineInterpolateImageFunction_txx
 
 #include "itkDiffusionTensor3DBSplineInterpolateImageFunction.h"
 

--- a/Source/itkDiffusionTensor3DConstants.h
+++ b/Source/itkDiffusionTensor3DConstants.h
@@ -1,5 +1,5 @@
-#ifndef __ResampleDTIVolumeConstant_h
-#define __ResampleDTIVolumeConstant_h
+#ifndef itkDiffusionTensor3DConstants_h
+#define itkDiffusionTensor3DConstants_h
 
 #define ITK_DIFFUSION_TENSOR_3D_ZERO (1e-10)
 

--- a/Source/itkDiffusionTensor3DExpImageFilter.h
+++ b/Source/itkDiffusionTensor3DExpImageFilter.h
@@ -23,7 +23,7 @@ namespace itk
  *
  * - cast the pixel value to \c DiffusionTensor3DExtended<double>,
  * - Compute the eigenvalues and the eigenvectors
- * - apply the \c vcl_exp() function to the eigenvalues
+ * - apply the \c std::exp() function to the eigenvalues
  *   of the output image
  * - store the casted value into the output image.
  *
@@ -68,7 +68,7 @@ public:
     // mat.Fill(0);
     for( int i = 0; i < 3; i++ )
       {
-      mat[i][i] = vcl_exp( eigenValues[i] );
+      mat[i][i] = std::exp( eigenValues[i] );
       }
     eigenVectors = eigenVectors.GetTranspose();
     matexp = eigenVectors * mat * eigenVectors.GetInverse();

--- a/Source/itkDiffusionTensor3DExtended.h
+++ b/Source/itkDiffusionTensor3DExtended.h
@@ -35,9 +35,9 @@ public:
   typedef DiffusionTensor3DExtended   Self;
   typedef DiffusionTensor3D<DataType> Superclass;
   typedef Matrix<DataType, 3, 3>      MatrixType;
+
   DiffusionTensor3DExtended()
-  {
-  }
+   = default;
   DiffusionTensor3DExtended( const Superclass & tensor );
   // /Get a Symmetric matrix representing the tensor
   MatrixType GetTensor2Matrix();

--- a/Source/itkDiffusionTensor3DExtended.h
+++ b/Source/itkDiffusionTensor3DExtended.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DExtended.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DExtended_h
-#define __itkDiffusionTensor3DExtended_h
+#ifndef itkDiffusionTensor3DExtended_h
+#define itkDiffusionTensor3DExtended_h
 
 #include <itkDiffusionTensor3D.h>
 #include <itkMatrix.h>

--- a/Source/itkDiffusionTensor3DExtended.txx
+++ b/Source/itkDiffusionTensor3DExtended.txx
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DExtended.txx $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DExtended_txx
-#define __itkDiffusionTensor3DExtended_txx
+#ifndef itkDiffusionTensor3DExtended_txx
+#define itkDiffusionTensor3DExtended_txx
 
 #include "itkDiffusionTensor3DExtended.h"
 

--- a/Source/itkDiffusionTensor3DFSAffineTransform.h
+++ b/Source/itkDiffusionTensor3DFSAffineTransform.h
@@ -52,6 +52,10 @@ public:
   typedef SmartPointer<const Self>                         ConstPointer;
 
   itkNewMacro(Self);
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DFSAffineTransform, DiffusionTensor3DAffineTransform);
+
 protected:
   void PreCompute();
 

--- a/Source/itkDiffusionTensor3DFSAffineTransform.h
+++ b/Source/itkDiffusionTensor3DFSAffineTransform.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DFSAffineTransform.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DFSAffineTransform_h
-#define __itkDiffusionTensor3DFSAffineTransform_h
+#ifndef itkDiffusionTensor3DFSAffineTransform_h
+#define itkDiffusionTensor3DFSAffineTransform_h
 
 #include "itkDiffusionTensor3DAffineTransform.h"
 #include <vnl/vnl_matrix.h>

--- a/Source/itkDiffusionTensor3DFSAffineTransform.h
+++ b/Source/itkDiffusionTensor3DFSAffineTransform.h
@@ -57,7 +57,7 @@ public:
   itkTypeMacro(DiffusionTensor3DFSAffineTransform, DiffusionTensor3DAffineTransform);
 
 protected:
-  void PreCompute();
+  void PreCompute() override;
 
 private:
   MatrixTransformType ComputeMatrixSquareRoot( MatrixTransformType matrix );

--- a/Source/itkDiffusionTensor3DFSAffineTransform.txx
+++ b/Source/itkDiffusionTensor3DFSAffineTransform.txx
@@ -67,7 +67,7 @@ DiffusionTensor3DFSAffineTransform<TData>
   this->m_Transform = RotationMatrixTranspose * this->m_MeasurementFrame;
 
   this->ComputeOffset();
-  this->latestTime = Object::GetMTime();
+  this->m_LatestTime = Object::GetMTime();
 }
 
 template <class TData>

--- a/Source/itkDiffusionTensor3DFSAffineTransform.txx
+++ b/Source/itkDiffusionTensor3DFSAffineTransform.txx
@@ -29,14 +29,14 @@ DiffusionTensor3DFSAffineTransform<TData>
   vnl_matrix<double> M( 3, 3 );
   M = matrix.GetVnlMatrix();
   vnl_real_eigensystem             eig( M );
-  vnl_matrix<vcl_complex<double> > D( 3, 3 );
-  vnl_matrix<vcl_complex<double> > vnl_sqrMatrix( 3, 3 );
+  vnl_matrix<std::complex<double> > D( 3, 3 );
+  vnl_matrix<std::complex<double> > vnl_sqrMatrix( 3, 3 );
   D.fill( NumericTraits<TData>::ZeroValue() );
   for( int i = 0; i < 3; i++ )
     {
-    D.put( i, i, vcl_pow( eig.D.get( i, i ), 0.5 ) );
+    D.put( i, i, std::pow( eig.D.get( i, i ), 0.5 ) );
     }
-  vnl_sqrMatrix = eig.V * D * vnl_matrix_inverse<vcl_complex<double> >( eig.V );
+  vnl_sqrMatrix = eig.V * D * vnl_matrix_inverse<std::complex<double> >( eig.V );
   vnl_matrix<double> vnl_sqrMatrix_real( 3, 3 );
   vnl_sqrMatrix_real = vnl_real( vnl_sqrMatrix );
   for( int i = 0; i < 3; i++ )

--- a/Source/itkDiffusionTensor3DFSAffineTransform.txx
+++ b/Source/itkDiffusionTensor3DFSAffineTransform.txx
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DFSAffineTransform.txx $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2015-01-08 12:49:00 -0500 (Thu, 08 Jan 2015) $
-  Version:   $Revision: 23857 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DFSAffineTransform_txx
-#define __itkDiffusionTensor3DFSAffineTransform_txx
+#ifndef itkDiffusionTensor3DFSAffineTransform_txx
+#define itkDiffusionTensor3DFSAffineTransform_txx
 
 #include "itkDiffusionTensor3DFSAffineTransform.h"
 

--- a/Source/itkDiffusionTensor3DInterpolateImageFunction.h
+++ b/Source/itkDiffusionTensor3DInterpolateImageFunction.h
@@ -52,6 +52,9 @@ public:
   typedef typename Superclass::ContinuousIndexType ContinuousIndexType;
   typedef typename Superclass::IndexType           IndexType;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DInterpolateImageFunction, ImageFunction);
+
 // ///Copied from itkInterpolateImageFunction.h
 
   /** Interpolate the image at a point position

--- a/Source/itkDiffusionTensor3DInterpolateImageFunction.h
+++ b/Source/itkDiffusionTensor3DInterpolateImageFunction.h
@@ -105,7 +105,7 @@ public:
 //  itkGetMacro( DefaultPixelValue , TensorRealType ) ;
 protected:
   DiffusionTensor3DInterpolateImageFunction();
-  unsigned long latestTime;
+  unsigned long m_LatestTime;
 //  TensorRealType m_DefaultPixelValue ;
 //  TensorDataType m_DefaultPixel ;
 };

--- a/Source/itkDiffusionTensor3DInterpolateImageFunction.h
+++ b/Source/itkDiffusionTensor3DInterpolateImageFunction.h
@@ -67,7 +67,7 @@ public:
    *
    * ImageFunction::IsInsideBuffer() can be used to check bounds before
    * calling the method. */
-  virtual TensorDataType Evaluate( const PointType& point ) const
+  TensorDataType Evaluate( const PointType& point ) const override
   {
     ContinuousIndexType index;
 
@@ -85,7 +85,7 @@ public:
    *
    * ImageFunction::IsInsideBuffer() can be used to check bounds before
    * calling the method. */
-  virtual TensorDataType EvaluateAtContinuousIndex( const ContinuousIndexType & index ) const = 0;
+  TensorDataType EvaluateAtContinuousIndex( const ContinuousIndexType & index ) const override = 0;
 
   /** Interpolate the image at an index position.
    *
@@ -96,7 +96,7 @@ public:
    * ImageFunction::IsInsideBuffer() can be used to check bounds before
    * calling the method. */
 
-  virtual TensorDataType EvaluateAtIndex( const IndexType & index ) const
+  TensorDataType EvaluateAtIndex( const IndexType & index ) const override
   {
     return this->GetInputImage()->GetPixel( index );
   }

--- a/Source/itkDiffusionTensor3DInterpolateImageFunction.h
+++ b/Source/itkDiffusionTensor3DInterpolateImageFunction.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DInterpolateImageFunction.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DInterpolateImageFunction_h
-#define __itkDiffusionTensor3DInterpolateImageFunction_h
+#ifndef itkDiffusionTensor3DInterpolateImageFunction_h
+#define itkDiffusionTensor3DInterpolateImageFunction_h
 
 #include <itkObject.h>
 #include "itkDiffusionTensor3D.h"
@@ -45,10 +45,12 @@ public:
   typedef SmartPointer<Self>                        Pointer;
   typedef SmartPointer<const Self>                  ConstPointer;
   typedef typename TensorDataType::RealValueType    TensorRealType;
+
   typedef ImageFunction<Image<DiffusionTensor3D<TData>, 3>,
                         DiffusionTensor3D<TData>,
                         TCoordRep
                         > Superclass;
+
   typedef typename Superclass::ContinuousIndexType ContinuousIndexType;
   typedef typename Superclass::IndexType           IndexType;
 

--- a/Source/itkDiffusionTensor3DInterpolateImageFunction.txx
+++ b/Source/itkDiffusionTensor3DInterpolateImageFunction.txx
@@ -24,7 +24,7 @@ DiffusionTensor3DInterpolateImageFunction<TData, TCoordRep>
 ::DiffusionTensor3DInterpolateImageFunction()
 {
 //  m_InputImage = 0 ;
-  latestTime = 0;
+  m_LatestTime = 0;
 //  SetDefaultPixelValue( ITK_DIFFUSION_TENSOR_3D_ZERO ) ;
 }
 

--- a/Source/itkDiffusionTensor3DInterpolateImageFunction.txx
+++ b/Source/itkDiffusionTensor3DInterpolateImageFunction.txx
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DInterpolateImageFunction.txx $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DInterpolateImageFunction_txx
-#define __itkDiffusionTensor3DInterpolateImageFunction_txx
+#ifndef itkDiffusionTensor3DInterpolateImageFunction_txx
+#define itkDiffusionTensor3DInterpolateImageFunction_txx
 
 #include "itkDiffusionTensor3DInterpolateImageFunction.h"
 

--- a/Source/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h
+++ b/Source/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h
@@ -60,6 +60,10 @@ public:
   typedef typename DiffusionImageType::RegionType                        itkRegionType;
   typedef typename DiffusionImageType::SizeType                          SizeType;
   typedef typename Superclass::ContinuousIndexType                       ContinuousIndexType;
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DInterpolateImageFunctionReimplementation, DiffusionTensor3DInterpolateImageFunction);
+
   /** Evaluate the interpolated tensor at a position
    */
   // TensorDataType Evaluate( const PointType &point ) ;

--- a/Source/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h
+++ b/Source/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h
@@ -1,36 +1,26 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2014-09-15 22:57:09 -0400 (Mon, 15 Sep 2014) $
-  Version:   $Revision: 23682 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DInterpolateImageFunctionReimplementation_h
-#define __itkDiffusionTensor3DInterpolateImageFunctionReimplementation_h
+#ifndef itkDiffusionTensor3DInterpolateImageFunctionReimplementation_h
+#define itkDiffusionTensor3DInterpolateImageFunctionReimplementation_h
 
 #include "itkDiffusionTensor3DInterpolateImageFunction.h"
 #include <itkImage.h>
-// #include <itkImageRegionIteratorWithIndex.h>
 #include <itkInterpolateImageFunction.h>
 #include "itkSeparateComponentsOfADiffusionTensorImage.h"
-// #include <mutex>
 
 namespace itk
 {
-
-/*struct RegionType
-{
-  ImageRegion< 3 > itkRegion ;
-  bool Done ;
-  Index< 3 > PositionInImage ;
-  bool Stop ;
-};*/
 
 /**
  * \class DiffusionTensor3DInterpolateImageFunctionReimplementation
@@ -76,25 +66,9 @@ protected:
   DiffusionTensor3DInterpolateImageFunctionReimplementation();
   virtual void AllocateInterpolator() = 0;
 
-//  void SeparateImages() ;
-//  void AllocateImages() ;
-//  bool DivideRegion( int currentThread ) ;
-//  int RegionToDivide() ;
   typename InterpolateImageFunctionType::Pointer m_Interpol[6];
   ImagePointer m_ImageVec[6];
   int          m_NumberOfThreads;
-//  Semaphore::Pointer m_Threads ;
-//  int m_SplitAxis ;
-//  bool m_SeparationDone ;
-//  bool m_CannotSplit ;
-//  std::mutex m_Lock ;
-//  std::mutex m_LockNewThreadDetected ;
-//  std::vector< RegionType > m_ListRegions ;
-//  int m_NbThread ;
-//  std::mutex m_CheckRegionsDone ;
-//  bool m_ExceptionThrown ;
-//  SizeType m_Size ;
-//  bool m_AllocateInterpolatorsDone ;
 };
 
 } // end namespace itk

--- a/Source/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h
+++ b/Source/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h
@@ -19,7 +19,7 @@
 // #include <itkImageRegionIteratorWithIndex.h>
 #include <itkInterpolateImageFunction.h>
 #include "itkSeparateComponentsOfADiffusionTensorImage.h"
-// #include <itkMutexLock.h>
+// #include <mutex>
 
 namespace itk
 {
@@ -83,11 +83,11 @@ protected:
 //  int m_SplitAxis ;
 //  bool m_SeparationDone ;
 //  bool m_CannotSplit ;
-//  MutexLock::Pointer m_Lock ;
-//  MutexLock::Pointer m_LockNewThreadDetected ;
+//  std::mutex m_Lock ;
+//  std::mutex m_LockNewThreadDetected ;
 //  std::vector< RegionType > m_ListRegions ;
 //  int m_NbThread ;
-//  MutexLock::Pointer m_CheckRegionsDone ;
+//  std::mutex m_CheckRegionsDone ;
 //  bool m_ExceptionThrown ;
 //  SizeType m_Size ;
 //  bool m_AllocateInterpolatorsDone ;

--- a/Source/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h
+++ b/Source/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h
@@ -57,9 +57,9 @@ public:
   /** Evaluate the interpolated tensor at a position
    */
   // TensorDataType Evaluate( const PointType &point ) ;
-  TensorDataType EvaluateAtContinuousIndex( const ContinuousIndexType & index ) const;
+  TensorDataType EvaluateAtContinuousIndex( const ContinuousIndexType & index ) const override;
 
-  virtual void SetInputImage( const DiffusionImageType *inputImage );
+  void SetInputImage( const DiffusionImageType *inputImage ) override;
 
   itkSetMacro( NumberOfThreads, int );
 protected:

--- a/Source/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.txx
+++ b/Source/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.txx
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.txx $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __DiffusionTensor3DInterpolateImageFunctionReimplementation_txx
-#define __DiffusionTensor3DInterpolateImageFunctionReimplementation_txx
+#ifndef itkDiffusionTensor3DInterpolateImageFunctionReimplementation_txx
+#define itkDiffusionTensor3DInterpolateImageFunctionReimplementation_txx
 
 #include "itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h"
 

--- a/Source/itkDiffusionTensor3DLinearInterpolateFunction.h
+++ b/Source/itkDiffusionTensor3DLinearInterpolateFunction.h
@@ -37,6 +37,9 @@ public:
   typedef LinearInterpolateImageFunction<ImageType,
                                          TCoordRep>                           LinearInterpolateImageFunctionType;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DLinearInterpolateFunction, DiffusionTensor3DInterpolateImageFunctionReimplementation);
+
   itkNewMacro(Self);
 protected:
   void AllocateInterpolator();

--- a/Source/itkDiffusionTensor3DLinearInterpolateFunction.h
+++ b/Source/itkDiffusionTensor3DLinearInterpolateFunction.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DLinearInterpolateFunction.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DLinearInterpolateFunction_h
-#define __itkDiffusionTensor3DLinearInterpolateFunction_h
+#ifndef itkDiffusionTensor3DLinearInterpolateFunction_h
+#define itkDiffusionTensor3DLinearInterpolateFunction_h
 
 #include "itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h"
 #include <itkLinearInterpolateImageFunction.h>

--- a/Source/itkDiffusionTensor3DLinearInterpolateFunction.h
+++ b/Source/itkDiffusionTensor3DLinearInterpolateFunction.h
@@ -42,7 +42,7 @@ public:
 
   itkNewMacro(Self);
 protected:
-  void AllocateInterpolator();
+  void AllocateInterpolator() override;
 
   typename LinearInterpolateImageFunctionType::Pointer linearInterpolator[6];
 };

--- a/Source/itkDiffusionTensor3DLinearInterpolateFunction.txx
+++ b/Source/itkDiffusionTensor3DLinearInterpolateFunction.txx
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DLinearInterpolateFunction.txx $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DLinearInterpolateFunction_txx
-#define __itkDiffusionTensor3DLinearInterpolateFunction_txx
+#ifndef itkDiffusionTensor3DLinearInterpolateFunction_txx
+#define itkDiffusionTensor3DLinearInterpolateFunction_txx
 
 #include "itkDiffusionTensor3DLinearInterpolateFunction.h"
 

--- a/Source/itkDiffusionTensor3DLogImageFilter.h
+++ b/Source/itkDiffusionTensor3DLogImageFilter.h
@@ -25,7 +25,7 @@ namespace itk
  *
  * - cast the pixel value to \c DiffusionTensor3DExtended<double>,
  * - Compute the eigenvalues and the eigenvectors
- * - apply the \c vcl_log() function to the eigenvalues
+ * - apply the \c std::log() function to the eigenvalues
  *   of the output image
  * - store the casted value into the output image.
  *
@@ -75,7 +75,7 @@ public:
 //      if( eigenValues[ i ] > 0 )
       if( eigenValues[i] > ZERO )
         {
-        mat[i][i] = vcl_log( eigenValues[i] );
+        mat[i][i] = std::log( eigenValues[i] );
         }
       else
         {

--- a/Source/itkDiffusionTensor3DMatrix3x3Transform.h
+++ b/Source/itkDiffusionTensor3DMatrix3x3Transform.h
@@ -48,6 +48,9 @@ public:
   typedef SmartPointer<Self>                               Pointer;
   typedef SmartPointer<const Self>                         ConstPointer;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DMatrix3x3Transform, DiffusionTensor3DTransform);
+
   // /Set the translation vector
   void SetTranslation( VectorType translation );
 

--- a/Source/itkDiffusionTensor3DMatrix3x3Transform.h
+++ b/Source/itkDiffusionTensor3DMatrix3x3Transform.h
@@ -92,7 +92,7 @@ protected:
   InternalMatrixTransformType m_TransformMatrix;
   InternalMatrixTransformType m_Transform;
   InternalMatrixTransformType m_TransformT;
-  unsigned long               latestTime;
+  unsigned long               m_LatestTime;
   VectorType                  m_Translation;
   VectorType                  m_Offset;
   PointType                   m_Center;

--- a/Source/itkDiffusionTensor3DMatrix3x3Transform.h
+++ b/Source/itkDiffusionTensor3DMatrix3x3Transform.h
@@ -61,7 +61,7 @@ public:
   void SetCenter( PointType center );
 
   // /Evaluate the position of the transformed tensor in the output image
-  PointType EvaluateTensorPosition( const PointType & point );
+  PointType EvaluateTensorPosition( const PointType & point ) override;
 
   // /Set the 3x3 transform matrix
   virtual void SetMatrix3x3( MatrixTransformType & matrix );
@@ -72,7 +72,7 @@ public:
   // /Evaluate the transformed tensor
   virtual TensorDataType EvaluateTransformedTensor( TensorDataType & tensor );
 
-  virtual TensorDataType EvaluateTransformedTensor( TensorDataType & tensor, PointType & outputPosition ); // dummy
+  TensorDataType EvaluateTransformedTensor( TensorDataType & tensor, PointType & outputPosition ) override; // dummy
                                                                                                            // output
                                                                                                            // position;
                                                                                                            // to be
@@ -81,7 +81,7 @@ public:
                                                                                                            // non-rigid
                                                                                                            // transforms
 
-  virtual typename Transform<double, 3, 3>::Pointer GetTransform();
+  typename Transform<double, 3, 3>::Pointer GetTransform() override;
 
 protected:
   void ComputeOffset();

--- a/Source/itkDiffusionTensor3DMatrix3x3Transform.h
+++ b/Source/itkDiffusionTensor3DMatrix3x3Transform.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DMatrix3x3Transform.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DMatrix3x3Transform_h
-#define __itkDiffusionTensor3DMatrix3x3Transform_h
+#ifndef itkDiffusionTensor3DMatrix3x3Transform_h
+#define itkDiffusionTensor3DMatrix3x3Transform_h
 
 #include "itkDiffusionTensor3DTransform.h"
 #include <itkVector.h>

--- a/Source/itkDiffusionTensor3DMatrix3x3Transform.h
+++ b/Source/itkDiffusionTensor3DMatrix3x3Transform.h
@@ -17,7 +17,7 @@
 #include "itkDiffusionTensor3DTransform.h"
 #include <itkVector.h>
 #include <itkMatrixOffsetTransformBase.h>
-#include <itkMutexLock.h>
+#include <mutex>
 
 namespace itk
 {
@@ -93,7 +93,7 @@ protected:
   VectorType                  m_Translation;
   VectorType                  m_Offset;
   PointType                   m_Center;
-  MutexLock::Pointer          m_Lock;
+  std::mutex                  m_Lock;
 };
 
 } // end namespace itk

--- a/Source/itkDiffusionTensor3DMatrix3x3Transform.txx
+++ b/Source/itkDiffusionTensor3DMatrix3x3Transform.txx
@@ -26,7 +26,6 @@ DiffusionTensor3DMatrix3x3Transform<TData>
   m_TransformMatrix.SetIdentity();
   m_Transform.SetIdentity();
   m_TransformT.SetIdentity();
-  m_Lock = MutexLock::New();
   latestTime = 0;
   m_Translation.Fill( NumericTraits<DataType>::ZeroValue() );
   m_Offset.Fill( NumericTraits<DataType>::ZeroValue() );
@@ -82,12 +81,12 @@ DiffusionTensor3DMatrix3x3Transform<TData>
 {
   if( latestTime < Object::GetMTime() )
     {
-    m_Lock->Lock();
+    m_Lock.lock();
     if( latestTime < Object::GetMTime() )
       {
       PreCompute();
       }
-    m_Lock->Unlock();
+    m_Lock.unlock();
     }
   return m_TransformMatrix * point + m_Offset;
 }
@@ -109,12 +108,12 @@ DiffusionTensor3DMatrix3x3Transform<TData>
 
   if( latestTime < Object::GetMTime() )
     {
-    m_Lock->Lock();
+    m_Lock.lock();
     if( latestTime < Object::GetMTime() )
       {
       PreCompute();
       }
-    m_Lock->Unlock();
+    m_Lock.unlock();
     }
   InternalMatrixDataType      tensorMatrix = internalTensor.GetTensor2Matrix();
   InternalMatrixTransformType mat = this->m_Transform
@@ -132,12 +131,12 @@ DiffusionTensor3DMatrix3x3Transform<TData>::GetMatrix3x3()
 {
   if( latestTime < Object::GetMTime() )
     {
-    m_Lock->Lock();
+    m_Lock.lock();
     if( latestTime < Object::GetMTime() )
       {
       PreCompute();
       }
-    m_Lock->Unlock();
+    m_Lock.unlock();
     }
   return m_TransformMatrix;
 }
@@ -149,12 +148,12 @@ DiffusionTensor3DMatrix3x3Transform<TData>::GetTranslation()
 {
   if( latestTime < Object::GetMTime() )
     {
-    m_Lock->Lock();
+    m_Lock.lock();
     if( latestTime < Object::GetMTime() )
       {
       PreCompute();
       }
-    m_Lock->Unlock();
+    m_Lock.unlock();
     }
   return m_Translation;
 }

--- a/Source/itkDiffusionTensor3DMatrix3x3Transform.txx
+++ b/Source/itkDiffusionTensor3DMatrix3x3Transform.txx
@@ -26,7 +26,7 @@ DiffusionTensor3DMatrix3x3Transform<TData>
   m_TransformMatrix.SetIdentity();
   m_Transform.SetIdentity();
   m_TransformT.SetIdentity();
-  latestTime = 0;
+  m_LatestTime = 0;
   m_Translation.Fill( NumericTraits<DataType>::ZeroValue() );
   m_Offset.Fill( NumericTraits<DataType>::ZeroValue() );
   m_Center.Fill( NumericTraits<DataType>::ZeroValue() );
@@ -79,10 +79,10 @@ typename DiffusionTensor3DMatrix3x3Transform<TData>::PointType
 DiffusionTensor3DMatrix3x3Transform<TData>
 ::EvaluateTensorPosition( const PointType & point )
 {
-  if( latestTime < Object::GetMTime() )
+  if( m_LatestTime < Object::GetMTime() )
     {
     m_Lock.lock();
-    if( latestTime < Object::GetMTime() )
+    if( m_LatestTime < Object::GetMTime() )
       {
       PreCompute();
       }
@@ -106,10 +106,10 @@ DiffusionTensor3DMatrix3x3Transform<TData>
 {
   InternalTensorDataType internalTensor = tensor;
 
-  if( latestTime < Object::GetMTime() )
+  if( m_LatestTime < Object::GetMTime() )
     {
     m_Lock.lock();
-    if( latestTime < Object::GetMTime() )
+    if( m_LatestTime < Object::GetMTime() )
       {
       PreCompute();
       }
@@ -129,10 +129,10 @@ typename DiffusionTensor3DMatrix3x3Transform<TData>::
 InternalMatrixTransformType
 DiffusionTensor3DMatrix3x3Transform<TData>::GetMatrix3x3()
 {
-  if( latestTime < Object::GetMTime() )
+  if( m_LatestTime < Object::GetMTime() )
     {
     m_Lock.lock();
-    if( latestTime < Object::GetMTime() )
+    if( m_LatestTime < Object::GetMTime() )
       {
       PreCompute();
       }
@@ -146,10 +146,10 @@ typename DiffusionTensor3DMatrix3x3Transform<TData>::
 VectorType
 DiffusionTensor3DMatrix3x3Transform<TData>::GetTranslation()
 {
-  if( latestTime < Object::GetMTime() )
+  if( m_LatestTime < Object::GetMTime() )
     {
     m_Lock.lock();
-    if( latestTime < Object::GetMTime() )
+    if( m_LatestTime < Object::GetMTime() )
       {
       PreCompute();
       }

--- a/Source/itkDiffusionTensor3DMatrix3x3Transform.txx
+++ b/Source/itkDiffusionTensor3DMatrix3x3Transform.txx
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DMatrix3x3Transform.txx $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2015-01-08 12:49:00 -0500 (Thu, 08 Jan 2015) $
-  Version:   $Revision: 23857 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DMatrix3x3Transform_txx
-#define __itkDiffusionTensor3DMatrix3x3Transform_txx
+#ifndef itkDiffusionTensor3DMatrix3x3Transform_txx
+#define itkDiffusionTensor3DMatrix3x3Transform_txx
 
 #include "itkDiffusionTensor3DMatrix3x3Transform.h"
 

--- a/Source/itkDiffusionTensor3DNearestCorrection.h
+++ b/Source/itkDiffusionTensor3DNearestCorrection.h
@@ -146,7 +146,7 @@ protected:
   DiffusionTensor3DNearestCorrectionFilter()
   {
   }
-  virtual ~DiffusionTensor3DNearestCorrectionFilter()
+  ~DiffusionTensor3DNearestCorrectionFilter() override
   {
   }
 private:

--- a/Source/itkDiffusionTensor3DNearestCorrection.h
+++ b/Source/itkDiffusionTensor3DNearestCorrection.h
@@ -125,6 +125,9 @@ public:
   typedef SmartPointer<Self>       Pointer;
   typedef SmartPointer<const Self> ConstPointer;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DNearestCorrectionFilter, UnaryFunctorImageFilter);
+
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
 

--- a/Source/itkDiffusionTensor3DNearestCorrection.h
+++ b/Source/itkDiffusionTensor3DNearestCorrection.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DNearestCorrection.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2014-03-02 19:08:33 -0500 (Sun, 02 Mar 2014) $
-  Version:   $Revision: 22915 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DNearestCorrectionFilter_h
-#define __itkDiffusionTensor3DNearestCorrectionFilter_h
+#ifndef itkDiffusionTensor3DNearestCorrection_h
+#define itkDiffusionTensor3DNearestCorrection_h
 
 #include "itkUnaryFunctorImageFilter.h"
 #include "vnl/vnl_math.h"

--- a/Source/itkDiffusionTensor3DNearestNeighborInterpolateFunction.h
+++ b/Source/itkDiffusionTensor3DNearestNeighborInterpolateFunction.h
@@ -39,6 +39,10 @@ public:
   typedef SmartPointer<const Self>                            ConstPointer;
   typedef ImageFunction<DiffusionImageType, DataType, double> ImageFunctionType;
   typedef typename Superclass::ContinuousIndexType            ContinuousIndexType;
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DNearestNeighborInterpolateFunction, DiffusionTensor3DInterpolateImageFunction);
+
   itkNewMacro( Self );
   // /Evaluate the value of a tensor at a given position
 //  TensorDataType Evaluate( const PointType &point ) ;

--- a/Source/itkDiffusionTensor3DNearestNeighborInterpolateFunction.h
+++ b/Source/itkDiffusionTensor3DNearestNeighborInterpolateFunction.h
@@ -46,7 +46,7 @@ public:
   itkNewMacro( Self );
   // /Evaluate the value of a tensor at a given position
 //  TensorDataType Evaluate( const PointType &point ) ;
-  TensorDataType EvaluateAtContinuousIndex( const ContinuousIndexType & index ) const;
+  TensorDataType EvaluateAtContinuousIndex( const ContinuousIndexType & index ) const override;
 
 protected:
 };

--- a/Source/itkDiffusionTensor3DNearestNeighborInterpolateFunction.h
+++ b/Source/itkDiffusionTensor3DNearestNeighborInterpolateFunction.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DNearestNeighborInterpolateFunction.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DNearestNeighborInterpolateFunction_h
-#define __itkDiffusionTensor3DNearestNeighborInterpolateFunction_h
+#ifndef itkDiffusionTensor3DNearestNeighborInterpolateFunction_h
+#define itkDiffusionTensor3DNearestNeighborInterpolateFunction_h
 
 #include "itkDiffusionTensor3DInterpolateImageFunction.h"
 

--- a/Source/itkDiffusionTensor3DNearestNeighborInterpolateFunction.txx
+++ b/Source/itkDiffusionTensor3DNearestNeighborInterpolateFunction.txx
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DNearestNeighborInterpolateFunction.txx $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DNearestNeighborInterpolateFunction_txx
-#define __itkDiffusionTensor3DNearestNeighborInterpolateFunction_txx
+#ifndef itkDiffusionTensor3DNearestNeighborInterpolateFunction_txx
+#define itkDiffusionTensor3DNearestNeighborInterpolateFunction_txx
 
 #include "itkDiffusionTensor3DNearestNeighborInterpolateFunction.h"
 

--- a/Source/itkDiffusionTensor3DNonRigidTransform.h
+++ b/Source/itkDiffusionTensor3DNonRigidTransform.h
@@ -59,9 +59,9 @@ public:
   void SetAffineTransformType(typename AffineTransform::Pointer transform);
 protected:
   DiffusionTensor3DNonRigidTransform();
+  unsigned long                     m_LatestTime;
   std::mutex m_LockGetJacobian;
-  unsigned long      latestTime;
-  typename TransformType::Pointer m_Transform;
+  typename TransformType::Pointer   m_Transform;
   typename AffineTransform::Pointer m_Affine;
 };
 

--- a/Source/itkDiffusionTensor3DNonRigidTransform.h
+++ b/Source/itkDiffusionTensor3DNonRigidTransform.h
@@ -18,7 +18,7 @@
 #include "itkDiffusionTensor3DFSAffineTransform.h"
 #include "itkDiffusionTensor3DPPDAffineTransform.h"
 #include <itkTransform.h>
-#include <itkMutexLock.h>
+#include <mutex>
 
 namespace itk
 {
@@ -55,7 +55,7 @@ public:
   void SetAffineTransformType(typename AffineTransform::Pointer transform);
 protected:
   DiffusionTensor3DNonRigidTransform();
-  MutexLock::Pointer m_LockGetJacobian;
+  std::mutex m_LockGetJacobian;
   unsigned long      latestTime;
   typename TransformType::Pointer m_Transform;
   typename AffineTransform::Pointer m_Affine;

--- a/Source/itkDiffusionTensor3DNonRigidTransform.h
+++ b/Source/itkDiffusionTensor3DNonRigidTransform.h
@@ -40,6 +40,10 @@ public:
   typedef itk::DiffusionTensor3DPPDAffineTransform<DataType> PPDAffineTransformType;
   typedef itk::DiffusionTensor3DFSAffineTransform<DataType>  FSAffineTransformType;
   typedef itk::DiffusionTensor3DAffineTransform<DataType>    AffineTransform;
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DNonRigidTransform, DiffusionTensor3DTransform);
+
   // SmartPointer
   itkNewMacro( Self );
   // /Set the transform

--- a/Source/itkDiffusionTensor3DNonRigidTransform.h
+++ b/Source/itkDiffusionTensor3DNonRigidTransform.h
@@ -18,7 +18,6 @@
 #include "itkDiffusionTensor3DFSAffineTransform.h"
 #include "itkDiffusionTensor3DPPDAffineTransform.h"
 #include <itkTransform.h>
-#include <mutex>
 
 namespace itk
 {
@@ -60,7 +59,6 @@ public:
 protected:
   DiffusionTensor3DNonRigidTransform();
   unsigned long                     m_LatestTime;
-  std::mutex m_LockGetJacobian;
   typename TransformType::Pointer   m_Transform;
   typename AffineTransform::Pointer m_Affine;
 };

--- a/Source/itkDiffusionTensor3DNonRigidTransform.h
+++ b/Source/itkDiffusionTensor3DNonRigidTransform.h
@@ -47,13 +47,13 @@ public:
   itkNewMacro( Self );
   // /Set the transform
   itkSetObjectMacro( Transform, TransformType );
-  TransformType::Pointer GetTransform();
+  TransformType::Pointer GetTransform() override;
 
   // /Evaluate the position of the transformed tensor in the output image
-  PointType EvaluateTensorPosition( const PointType & point );
+  PointType EvaluateTensorPosition( const PointType & point ) override;
 
   // /Evaluate the transformed tensor
-  virtual TensorDataType EvaluateTransformedTensor( TensorDataType & tensor, PointType & outputPosition );
+  TensorDataType EvaluateTransformedTensor( TensorDataType & tensor, PointType & outputPosition ) override;
 
   void SetAffineTransformType(typename AffineTransform::Pointer transform);
 protected:

--- a/Source/itkDiffusionTensor3DNonRigidTransform.h
+++ b/Source/itkDiffusionTensor3DNonRigidTransform.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DNonRigidTransform.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DNonRigidTransform_h
-#define __itkDiffusionTensor3DNonRigidTransform_h
+#ifndef itkDiffusionTensor3DNonRigidTransform_h
+#define itkDiffusionTensor3DNonRigidTransform_h
 
 #include "itkDiffusionTensor3DTransform.h"
 #include "itkDiffusionTensor3DFSAffineTransform.h"

--- a/Source/itkDiffusionTensor3DNonRigidTransform.txx
+++ b/Source/itkDiffusionTensor3DNonRigidTransform.txx
@@ -22,8 +22,7 @@ namespace itk
 template <class TData>
 DiffusionTensor3DNonRigidTransform<TData>
 ::DiffusionTensor3DNonRigidTransform()
-{
-}
+= default;
 
 template <class TData>
 void

--- a/Source/itkDiffusionTensor3DNonRigidTransform.txx
+++ b/Source/itkDiffusionTensor3DNonRigidTransform.txx
@@ -23,7 +23,6 @@ template <class TData>
 DiffusionTensor3DNonRigidTransform<TData>
 ::DiffusionTensor3DNonRigidTransform()
 {
-  m_LockGetJacobian = MutexLock::New();
 }
 
 template <class TData>
@@ -32,7 +31,6 @@ DiffusionTensor3DNonRigidTransform<TData>
 ::SetAffineTransformType(typename AffineTransform::Pointer transform)
 {
   m_Affine = transform;
-//  m_LockGetJacobian = MutexLock::New() ;
 }
 
 template <class TData>

--- a/Source/itkDiffusionTensor3DNonRigidTransform.txx
+++ b/Source/itkDiffusionTensor3DNonRigidTransform.txx
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DNonRigidTransform.txx $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2014-04-11 00:10:41 -0400 (Fri, 11 Apr 2014) $
-  Version:   $Revision: 23077 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DNonRigidTransform_txx
-#define __itkDiffusionTensor3DNonRigidTransform_txx
+#ifndef itkDiffusionTensor3DNonRigidTransform_txx
+#define itkDiffusionTensor3DNonRigidTransform_txx
 
 #include "itkDiffusionTensor3DNonRigidTransform.h"
 

--- a/Source/itkDiffusionTensor3DPPDAffineTransform.h
+++ b/Source/itkDiffusionTensor3DPPDAffineTransform.h
@@ -50,6 +50,10 @@ public:
   typedef typename Superclass::VectorType                           VectorType;
   typedef DiffusionTensor3DExtended<double>::EigenValuesArrayType   EValuesType;
   typedef DiffusionTensor3DExtended<double>::EigenVectorsMatrixType EVectorsType;
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DPPDAffineTransform, DiffusionTensor3DAffineTransform);
+
   itkNewMacro( Self );
   using Superclass::EvaluateTransformedTensor;
   virtual TensorDataType EvaluateTransformedTensor( TensorDataType & tensor );

--- a/Source/itkDiffusionTensor3DPPDAffineTransform.h
+++ b/Source/itkDiffusionTensor3DPPDAffineTransform.h
@@ -56,12 +56,12 @@ public:
 
   itkNewMacro( Self );
   using Superclass::EvaluateTransformedTensor;
-  virtual TensorDataType EvaluateTransformedTensor( TensorDataType & tensor );
+  TensorDataType EvaluateTransformedTensor( TensorDataType & tensor ) override;
 
   void SetMatrix( MatrixTransformType & matrix );
 
 protected:
-  void PreCompute();
+  void PreCompute() override;
 
   InternalMatrixTransformType ComputeMatrixFromAxisAndAngle( VectorType axis, double cosangle );
 

--- a/Source/itkDiffusionTensor3DPPDAffineTransform.h
+++ b/Source/itkDiffusionTensor3DPPDAffineTransform.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DPPDAffineTransform.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DPPDAffineTransform_h
-#define __itkDiffusionTensor3DPPDAffineTransform_h
+#ifndef itkDiffusionTensor3DPPDAffineTransform_h
+#define itkDiffusionTensor3DPPDAffineTransform_h
 
 #include "itkDiffusionTensor3DAffineTransform.h"
 #include <vnl/vnl_vector.h>

--- a/Source/itkDiffusionTensor3DPPDAffineTransform.txx
+++ b/Source/itkDiffusionTensor3DPPDAffineTransform.txx
@@ -45,12 +45,12 @@ DiffusionTensor3DPPDAffineTransform<TData>
 
   if( this->latestTime < Object::GetMTime() )
     {
-    this->m_Lock->Lock();
+    this->m_Lock.lock();
     if( this->latestTime < Object::GetMTime() )
       {
       PreCompute();
       }
-    this->m_Lock->Unlock();
+    this->m_Lock.unlock();
     }
   EValuesType                       eigenValues;
   EVectorsType                      eigenVectors;

--- a/Source/itkDiffusionTensor3DPPDAffineTransform.txx
+++ b/Source/itkDiffusionTensor3DPPDAffineTransform.txx
@@ -33,7 +33,7 @@ DiffusionTensor3DPPDAffineTransform<TData>
     itkExceptionMacro(<< "Transform matrix is not invertible" );
     }
   this->ComputeOffset();
-  this->latestTime = Object::GetMTime();
+  this->m_LatestTime = Object::GetMTime();
 }
 
 template <class TData>
@@ -43,10 +43,10 @@ DiffusionTensor3DPPDAffineTransform<TData>
 {
   InternalTensorDataType internalTensor = tensor;
 
-  if( this->latestTime < Object::GetMTime() )
+  if( this->m_LatestTime < Object::GetMTime() )
     {
     this->m_Lock.lock();
-    if( this->latestTime < Object::GetMTime() )
+    if( this->m_LatestTime < Object::GetMTime() )
       {
       PreCompute();
       }

--- a/Source/itkDiffusionTensor3DPPDAffineTransform.txx
+++ b/Source/itkDiffusionTensor3DPPDAffineTransform.txx
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DPPDAffineTransform.txx $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2014-03-02 19:08:33 -0500 (Sun, 02 Mar 2014) $
-  Version:   $Revision: 22915 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DPPDAffineTransform_txx
-#define __itkDiffusionTensor3DPPDAffineTransform_txx
+#ifndef itkDiffusionTensor3DPPDAffineTransform_txx
+#define itkDiffusionTensor3DPPDAffineTransform_txx
 
 #include "itkDiffusionTensor3DPPDAffineTransform.h"
 

--- a/Source/itkDiffusionTensor3DRead.h
+++ b/Source/itkDiffusionTensor3DRead.h
@@ -49,6 +49,9 @@ public:
   typedef SmartPointer<Self>                   Pointer;
   typedef SmartPointer<const Self>             ConstPointer;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DRead, Object);
+
   itkNewMacro( Self );
   int Update( const char* input );
 

--- a/Source/itkDiffusionTensor3DRead.h
+++ b/Source/itkDiffusionTensor3DRead.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer3/trunk/Applications/CLI/DiffusionApplications/ResampleDTI/itkDiffusionTensor3DRead.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2010-06-28 07:45:15 -0400 (Mon, 28 Jun 2010) $
-  Version:   $Revision: 13964 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DRead_h
-#define __itkDiffusionTensor3DRead_h
+#ifndef itkDiffusionTensor3DRead_h
+#define itkDiffusionTensor3DRead_h
 
 #include <itkObject.h>
 #include <itkMetaDataObject.h>
@@ -69,7 +69,9 @@ public:
   itkGetMacro( HasMeasurementFrame , bool ) ;
 private:
   DiffusionTensor3DRead();
+
   typename FileReaderType::Pointer m_Reader;
+
   MatrixType   m_MeasurementFrame;
   unsigned int m_NumberOfThreads;
   bool m_CatchExceptions ;

--- a/Source/itkDiffusionTensor3DRead.txx
+++ b/Source/itkDiffusionTensor3DRead.txx
@@ -1,25 +1,24 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer3/trunk/Applications/CLI/DiffusionApplications/ResampleDTI/itkDiffusionTensor3DRead.txx $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2008-11-25 14:23:08 -0500 (Tue, 25 Nov 2008) $
-  Version:   $Revision: 7976 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DRead_txx
-#define __itkDiffusionTensor3DRead_txx
+#ifndef itkDiffusionTensor3DRead_txx
+#define itkDiffusionTensor3DRead_txx
 
 #include "itkDiffusionTensor3DRead.h"
 
 namespace itk
 {
-  
-  
+
 template< class TData >
 DiffusionTensor3DRead< TData >
 ::DiffusionTensor3DRead()
@@ -30,7 +29,6 @@ DiffusionTensor3DRead< TData >
   m_HasMeasurementFrame = false ; 
 }
 
-
 template< class TData >
 typename DiffusionTensor3DRead< TData >::DiffusionImagePointer
 DiffusionTensor3DRead< TData >
@@ -38,7 +36,6 @@ DiffusionTensor3DRead< TData >
 {
   return m_Reader->GetOutput() ;
 }
-
 
 template< class TData >
 typename DiffusionTensor3DRead< TData >::DictionaryType
@@ -96,6 +93,7 @@ DiffusionTensor3DRead< TData >
       }
     ++itr ;
     }
+
     return 0;
   }
   catch( itk::ExceptionObject &excep )

--- a/Source/itkDiffusionTensor3DRead.txx
+++ b/Source/itkDiffusionTensor3DRead.txx
@@ -77,7 +77,7 @@ DiffusionTensor3DRead< TData >
             m_MeasurementFrame[ i ][ j ] = tagvalue.at( j ).at( i ) ;
             }
           }
-        m_HasMeasurementFrame = 1 ;
+        m_HasMeasurementFrame = true;
         } 
       }
     //get the space orientation

--- a/Source/itkDiffusionTensor3DResample.h
+++ b/Source/itkDiffusionTensor3DResample.h
@@ -61,6 +61,9 @@ public:
   typedef typename OutputImageType::RegionType                     OutputImageRegionType;
 // typedef typename OutputTensorDataType::RealValueType TensorRealType ;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DResample, ImageToImageFilter);
+
   itkNewMacro( Self );
 // /Set the transform
   itkSetObjectMacro( Transform, TransformType );

--- a/Source/itkDiffusionTensor3DResample.h
+++ b/Source/itkDiffusionTensor3DResample.h
@@ -75,7 +75,7 @@ public:
   void SetOutputParametersFromImage( InputImagePointerType Image );
 
 // /Get the time of the last modification of the object
-  unsigned long GetMTime() const;
+  unsigned long GetMTime() const override;
 
   itkSetMacro( DefaultPixelValue, OutputDataType );
   itkGetMacro( DefaultPixelValue, OutputDataType );
@@ -95,13 +95,13 @@ protected:
 
   void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId );
 
-  void BeforeThreadedGenerateData();
+  void BeforeThreadedGenerateData() override;
 
-  void GenerateOutputInformation();
+  void GenerateOutputInformation() override;
 
-  void AfterThreadedGenerateData();
+  void AfterThreadedGenerateData() override;
 
-  void GenerateInputRequestedRegion();
+  void GenerateInputRequestedRegion() override;
 
 private:
   typename InterpolatorType::Pointer      m_Interpolator;

--- a/Source/itkDiffusionTensor3DResample.h
+++ b/Source/itkDiffusionTensor3DResample.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DResample.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2014-04-11 00:10:41 -0400 (Fri, 11 Apr 2014) $
-  Version:   $Revision: 23077 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DResample_h
-#define __itkDiffusionTensor3DResample_h
+#ifndef itkDiffusionTensor3DResample_h
+#define itkDiffusionTensor3DResample_h
 
 #include <itkObject.h>
 #include <itkImageToImageFilter.h>
@@ -42,10 +42,11 @@ class DiffusionTensor3DResample
 public:
   typedef TInput  InputDataType;
   typedef TOutput OutputDataType;
+
   typedef ImageToImageFilter
   <Image<DiffusionTensor3D<TInput>, 3>,
-   Image<DiffusionTensor3D<TOutput>, 3> >
-  Superclass;
+   Image<DiffusionTensor3D<TOutput>, 3> > Superclass;
+
   typedef DiffusionTensor3D<InputDataType>                         InputTensorDataType;
   typedef Image<InputTensorDataType, 3>                            InputImageType;
   typedef DiffusionTensor3D<OutputDataType>                        OutputTensorDataType;
@@ -103,14 +104,14 @@ protected:
   void GenerateInputRequestedRegion();
 
 private:
-  typename InterpolatorType::Pointer m_Interpolator;
-  typename TransformType::Pointer m_Transform;
-  typename OutputImageType::PointType m_OutputOrigin;
-  typename OutputImageType::SpacingType m_OutputSpacing;
-  typename OutputImageType::SizeType m_OutputSize;
+  typename InterpolatorType::Pointer      m_Interpolator;
+  typename TransformType::Pointer         m_Transform;
+  typename OutputImageType::PointType     m_OutputOrigin;
+  typename OutputImageType::SpacingType   m_OutputSpacing;
+  typename OutputImageType::SizeType      m_OutputSize;
   typename OutputImageType::DirectionType m_OutputDirection;
-  OutputDataType       m_DefaultPixelValue;
-  OutputTensorDataType m_DefaultTensor;
+  OutputDataType                          m_DefaultPixelValue;
+  OutputTensorDataType                    m_DefaultTensor;
 };
 
 } // end namespace itk

--- a/Source/itkDiffusionTensor3DResample.h
+++ b/Source/itkDiffusionTensor3DResample.h
@@ -93,7 +93,7 @@ public:
 protected:
   DiffusionTensor3DResample();
 
-  void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId );
+  void DynamicThreadedGenerateData( const OutputImageRegionType & outputRegionForThread) override;
 
   void BeforeThreadedGenerateData() override;
 

--- a/Source/itkDiffusionTensor3DResample.txx
+++ b/Source/itkDiffusionTensor3DResample.txx
@@ -83,10 +83,9 @@ DiffusionTensor3DResample<TInput, TOutput>
 template <class TInput, class TOutput>
 void
 DiffusionTensor3DResample<TInput, TOutput>
-::ThreadedGenerateData( const OutputImageRegionType &outputRegionForThread,
-                        ThreadIdType itkNotUsed(threadId) )
+::DynamicThreadedGenerateData( const OutputImageRegionType &outputRegionForThread)
   {
-  OutputImagePointerType outputImagePtr = this->GetOutput( 0 );
+  OutputImageType*       outputImagePtr = this->GetOutput( 0 );
   IteratorType           it( outputImagePtr, outputRegionForThread );
   InputTensorDataType    inputTensor;
   OutputTensorDataType   outputTensor;

--- a/Source/itkDiffusionTensor3DResample.txx
+++ b/Source/itkDiffusionTensor3DResample.txx
@@ -166,7 +166,7 @@ void
 DiffusionTensor3DResample<TInput, TOutput>
 ::AfterThreadedGenerateData()
 {
-  m_Interpolator->SetInputImage( NULL );
+  m_Interpolator->SetInputImage( nullptr );
 }
 
 /**

--- a/Source/itkDiffusionTensor3DResample.txx
+++ b/Source/itkDiffusionTensor3DResample.txx
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DResample.txx $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2014-04-11 00:10:41 -0400 (Fri, 11 Apr 2014) $
-  Version:   $Revision: 23077 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DResample_txx
-#define __itkDiffusionTensor3DResample_txx
+#ifndef itkDiffusionTensor3DResample_txx
+#define itkDiffusionTensor3DResample_txx
 
 #include "itkDiffusionTensor3DResample.h"
 

--- a/Source/itkDiffusionTensor3DRigidTransform.h
+++ b/Source/itkDiffusionTensor3DRigidTransform.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DRigidTransform.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2015-02-05 10:02:04 -0500 (Thu, 05 Feb 2015) $
-  Version:   $Revision: 23962 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DRigidTransform_h
-#define __itkDiffusionTensor3DRigidTransform_h
+#ifndef itkDiffusionTensor3DRigidTransform_h
+#define itkDiffusionTensor3DRigidTransform_h
 
 #include "itkDiffusionTensor3DMatrix3x3Transform.h"
 #include <itkVersorRigid3DTransform.h>

--- a/Source/itkDiffusionTensor3DRigidTransform.h
+++ b/Source/itkDiffusionTensor3DRigidTransform.h
@@ -52,7 +52,7 @@ public:
 
   itkNewMacro( Self );
   // /Set the 3x3 rotation matrix
-  void SetMatrix3x3( MatrixTransformType & matrix );
+  void SetMatrix3x3( MatrixTransformType & matrix ) override;
 
   void DisablePrecision();
 
@@ -62,7 +62,7 @@ protected:
   bool m_PrecisionChecking;
   double GetDet( MatrixTransformType & matrix );
 
-  void PreCompute();
+  void PreCompute() override;
 
 };
 

--- a/Source/itkDiffusionTensor3DRigidTransform.h
+++ b/Source/itkDiffusionTensor3DRigidTransform.h
@@ -47,6 +47,9 @@ public:
   void SetTransform( typename Rigid3DTransformType::Pointer transform );
   typename VersorRigid3DTransformType::Pointer GetRigidTransform();
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DRigidTransform, DiffusionTensor3DMatrix3x3Transform);
+
   itkNewMacro( Self );
   // /Set the 3x3 rotation matrix
   void SetMatrix3x3( MatrixTransformType & matrix );

--- a/Source/itkDiffusionTensor3DRigidTransform.txx
+++ b/Source/itkDiffusionTensor3DRigidTransform.txx
@@ -155,7 +155,7 @@ DiffusionTensor3DRigidTransform<TData>
   this->m_TransformT = MeasurementFrameTranspose * this->m_TransformMatrix;
   this->m_Transform = TransformMatrixTranspose * this->m_MeasurementFrame;
   this->ComputeOffset();
-  this->latestTime = Object::GetMTime();
+  this->m_LatestTime = Object::GetMTime();
 
 }
 

--- a/Source/itkDiffusionTensor3DRigidTransform.txx
+++ b/Source/itkDiffusionTensor3DRigidTransform.txx
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DRigidTransform.txx $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2015-02-05 10:02:04 -0500 (Thu, 05 Feb 2015) $
-  Version:   $Revision: 23962 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DRigidTransform_txx
-#define __itkDiffusionTensor3DRigidTransform_txx
+#ifndef itkDiffusionTensor3DRigidTransform_txx
+#define itkDiffusionTensor3DRigidTransform_txx
 
 #include "itkDiffusionTensor3DRigidTransform.h"
 

--- a/Source/itkDiffusionTensor3DTransform.h
+++ b/Source/itkDiffusionTensor3DTransform.h
@@ -43,6 +43,10 @@ public:
   typedef MatrixExtended<DataType, 3, 3>      InternalMatrixDataType;
   typedef SmartPointer<Self>                  Pointer;
   typedef SmartPointer<const Self>            ConstPointer;
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DTransform, Object);
+
   // /Evaluate the position of the transformed tensor
   virtual PointType EvaluateTensorPosition( const PointType & point ) = 0;
 

--- a/Source/itkDiffusionTensor3DTransform.h
+++ b/Source/itkDiffusionTensor3DTransform.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DTransform.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DTransform_h
-#define __itkDiffusionTensor3DTransform_h
+#ifndef itkDiffusionTensor3DTransform_h
+#define itkDiffusionTensor3DTransform_h
 
 #include <itkObject.h>
 #include "itkDiffusionTensor3DExtended.h"

--- a/Source/itkDiffusionTensor3DTransform.txx
+++ b/Source/itkDiffusionTensor3DTransform.txx
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DTransform.txx $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DTransform_txx
-#define __itkDiffusionTensor3DTransform_txx
+#ifndef itkDiffusionTensor3DTransform_txx
+#define itkDiffusionTensor3DTransform_txx
 
 #include "itkDiffusionTensor3DTransform.h"
 

--- a/Source/itkDiffusionTensor3DWindowedSincInterpolateImageFunction.h
+++ b/Source/itkDiffusionTensor3DWindowedSincInterpolateImageFunction.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWindowedSincInterpolateImageFunction.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2013-01-11 16:30:04 -0500 (Fri, 11 Jan 2013) $
-  Version:   $Revision: 21594 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DWindowedSincInterpolateImageFunction_h
-#define __itkDiffusionTensor3DWindowedSincInterpolateImageFunction_h
+#ifndef itkDiffusionTensor3DWindowedSincInterpolateImageFunction_h
+#define itkDiffusionTensor3DWindowedSincInterpolateImageFunction_h
 
 #include "itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h"
 #include <itkWindowedSincInterpolateImageFunction.h>

--- a/Source/itkDiffusionTensor3DWindowedSincInterpolateImageFunction.h
+++ b/Source/itkDiffusionTensor3DWindowedSincInterpolateImageFunction.h
@@ -46,6 +46,9 @@ public:
                                                VRadius, TWindowFunction,
                                                TBoundaryCondition, TCoordRep> WindowedSincInterpolateImageFunctionType;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DWindowedSincInterpolateImageFunction, DiffusionTensor3DInterpolateImageFunctionReimplementation);
+
   itkNewMacro(Self);
 protected:
   void AllocateInterpolator();

--- a/Source/itkDiffusionTensor3DWindowedSincInterpolateImageFunction.h
+++ b/Source/itkDiffusionTensor3DWindowedSincInterpolateImageFunction.h
@@ -51,7 +51,7 @@ public:
 
   itkNewMacro(Self);
 protected:
-  void AllocateInterpolator();
+  void AllocateInterpolator() override;
 
   typename WindowedSincInterpolateImageFunctionType::Pointer windowedSincInterpolator[6];
 };

--- a/Source/itkDiffusionTensor3DWindowedSincInterpolateImageFunction.txx
+++ b/Source/itkDiffusionTensor3DWindowedSincInterpolateImageFunction.txx
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWindowedSincInterpolateImageFunction.txx $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DWindowedSincInterpolateFunction_txx
-#define __itkDiffusionTensor3DWindowedSincInterpolateFunction_txx
+#ifndef itkDiffusionTensor3DWindowedSincInterpolateImageFunction_txx
+#define itkDiffusionTensor3DWindowedSincInterpolateImageFunction_txx
 
 #include "itkDiffusionTensor3DWindowedSincInterpolateImageFunction.h"
 

--- a/Source/itkDiffusionTensor3DWrite.h
+++ b/Source/itkDiffusionTensor3DWrite.h
@@ -45,6 +45,10 @@ public:
   typedef std::vector<std::vector<double> >   DoubleVectorType;
   typedef MetaDataObject<DoubleVectorType>    MetaDataDoubleVectorType;
   typedef MetaDataObject<std::string>         MetaDataIntType;
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DWrite, Object);
+
   itkNewMacro( Self );
   // /Set input tensor image
   itkSetObjectMacro( Input, DiffusionImageType );

--- a/Source/itkDiffusionTensor3DWrite.h
+++ b/Source/itkDiffusionTensor3DWrite.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWrite.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DWrite_h
-#define __itkDiffusionTensor3DWrite_h
+#ifndef itkDiffusionTensor3DWrite_h
+#define itkDiffusionTensor3DWrite_h
 
 #include <itkObject.h>
 #include <itkMetaDataObject.h>
@@ -86,7 +86,9 @@ public:
 
 private:
   DiffusionTensor3DWrite();
+
   typename DiffusionImageType::Pointer m_Input;
+
   unsigned int   m_NumberOfThreads;
   DictionaryType m_MetaDataDictionary;
 };

--- a/Source/itkDiffusionTensor3DWrite.txx
+++ b/Source/itkDiffusionTensor3DWrite.txx
@@ -121,7 +121,7 @@ DiffusionTensor3DWrite<TData>
     writer->Update();
     return 0;
     }
-  catch( itk::ExceptionObject excep )
+  catch( itk::ExceptionObject &excep )
     {
     std::cerr
     << "DiffusionTensor3DWrite::Write: exception caught !" << std::endl;

--- a/Source/itkDiffusionTensor3DWrite.txx
+++ b/Source/itkDiffusionTensor3DWrite.txx
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWrite.txx $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2014-04-11 00:10:41 -0400 (Fri, 11 Apr 2014) $
-  Version:   $Revision: 23077 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DWrite_txx
-#define __itkDiffusionTensor3DWrite_txx
+#ifndef itkDiffusionTensor3DWrite_txx
+#define itkDiffusionTensor3DWrite_txx
 
 #include "itkDiffusionTensor3DWrite.h"
 

--- a/Source/itkDiffusionTensor3DZeroCorrection.h
+++ b/Source/itkDiffusionTensor3DZeroCorrection.h
@@ -129,7 +129,7 @@ protected:
   DiffusionTensor3DZeroCorrectionFilter()
   {
   }
-  virtual ~DiffusionTensor3DZeroCorrectionFilter()
+  ~DiffusionTensor3DZeroCorrectionFilter() override
   {
   }
 private:

--- a/Source/itkDiffusionTensor3DZeroCorrection.h
+++ b/Source/itkDiffusionTensor3DZeroCorrection.h
@@ -108,6 +108,9 @@ public:
   typedef SmartPointer<Self>       Pointer;
   typedef SmartPointer<const Self> ConstPointer;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DiffusionTensor3DZeroCorrectionFilter, UnaryFunctorImageFilter);
+
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
 

--- a/Source/itkDiffusionTensor3DZeroCorrection.h
+++ b/Source/itkDiffusionTensor3DZeroCorrection.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DZeroCorrection.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2014-03-02 19:08:33 -0500 (Sun, 02 Mar 2014) $
-  Version:   $Revision: 22915 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkDiffusionTensor3DZeroCorrectionFilter_h
-#define __itkDiffusionTensor3DZeroCorrectionFilter_h
+#ifndef itkDiffusionTensor3DZeroCorrection_h
+#define itkDiffusionTensor3DZeroCorrection_h
 
 #include "itkUnaryFunctorImageFilter.h"
 #include "vnl/vnl_math.h"

--- a/Source/itkMatrixExtended.h
+++ b/Source/itkMatrixExtended.h
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkMatrixExtended.h $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkMatrixExtended_h
-#define __itkMatrixExtended_h
+#ifndef itkMatrixExtended_h
+#define itkMatrixExtended_h
 
 #include "itkMatrix.h"
 

--- a/Source/itkMatrixExtended.txx
+++ b/Source/itkMatrixExtended.txx
@@ -1,18 +1,18 @@
 /*=========================================================================
 
   Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ResampleDTIVolume/itkMatrixExtended.txx $
+  Module:    $HeadURL$
   Language:  C++
-  Date:      $Date: 2012-02-02 01:52:52 -0500 (Thu, 02 Feb 2012) $
-  Version:   $Revision: 19197 $
+  Date:      $Date$
+  Version:   $Revision$
 
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkMatrixExtended_txx
-#define __itkMatrixExtended_txx
+#ifndef itkMatrixExtended_txx
+#define itkMatrixExtended_txx
 
 #include "itkMatrixExtended.h"
 

--- a/Source/itkSeparateComponentsOfADiffusionTensorImage.h
+++ b/Source/itkSeparateComponentsOfADiffusionTensorImage.h
@@ -11,8 +11,8 @@
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkSeparateComponentsOfADiffusionTensorImage_h
-#define __itkSeparateComponentsOfADiffusionTensorImage_h
+#ifndef itkSeparateComponentsOfADiffusionTensorImage_h
+#define itkSeparateComponentsOfADiffusionTensorImage_h
 
 #include <itkImageToImageFilter.h>
 #include <itkImage.h>
@@ -35,10 +35,12 @@ class SeparateComponentsOfADiffusionTensorImage
 public:
   typedef TInput  InputDataType;
   typedef TOutput OutputDataType;
+
   typedef ImageToImageFilter
   <Image<DiffusionTensor3D<TInput>, 3>,
    Image<TOutput, 3> >
   Superclass;
+
   typedef DiffusionTensor3D<InputDataType>              InputTensorDataType;
   typedef Image<InputTensorDataType, 3>                 InputImageType;
   typedef SeparateComponentsOfADiffusionTensorImage     Self;

--- a/Source/itkSeparateComponentsOfADiffusionTensorImage.h
+++ b/Source/itkSeparateComponentsOfADiffusionTensorImage.h
@@ -52,6 +52,9 @@ public:
   typedef typename OutputImageType::RegionType          OutputImageRegionType;
 // typedef typename OutputTensorDataType::RealValueType TensorRealType ;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(SeparateComponentsOfADiffusionTensorImage, ImageToImageFilter);
+
   itkNewMacro( Self );
 protected:
   SeparateComponentsOfADiffusionTensorImage();

--- a/Source/itkSeparateComponentsOfADiffusionTensorImage.h
+++ b/Source/itkSeparateComponentsOfADiffusionTensorImage.h
@@ -61,7 +61,7 @@ public:
 protected:
   SeparateComponentsOfADiffusionTensorImage();
 
-  void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId );
+  void DynamicThreadedGenerateData( const OutputImageRegionType & outputRegionForThread) override;
 
   void GenerateOutputInformation() override;
 

--- a/Source/itkSeparateComponentsOfADiffusionTensorImage.h
+++ b/Source/itkSeparateComponentsOfADiffusionTensorImage.h
@@ -63,9 +63,9 @@ protected:
 
   void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId );
 
-  void GenerateOutputInformation();
+  void GenerateOutputInformation() override;
 
-  void GenerateInputRequestedRegion();
+  void GenerateInputRequestedRegion() override;
 
 private:
 

--- a/Source/itkSeparateComponentsOfADiffusionTensorImage.txx
+++ b/Source/itkSeparateComponentsOfADiffusionTensorImage.txx
@@ -11,8 +11,8 @@
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
 
 ==========================================================================*/
-#ifndef __itkSeparateComponentsOfADiffusionTensorImage_txx
-#define __itkSeparateComponentsOfADiffusionTensorImage_txx
+#ifndef itkSeparateComponentsOfADiffusionTensorImage_txx
+#define itkSeparateComponentsOfADiffusionTensorImage_txx
 
 #include "itkSeparateComponentsOfADiffusionTensorImage.h"
 

--- a/Source/itkSeparateComponentsOfADiffusionTensorImage.txx
+++ b/Source/itkSeparateComponentsOfADiffusionTensorImage.txx
@@ -38,8 +38,7 @@ SeparateComponentsOfADiffusionTensorImage<TInput, TOutput>
 template <class TInput, class TOutput>
 void
 SeparateComponentsOfADiffusionTensorImage<TInput, TOutput>
-::ThreadedGenerateData( const OutputImageRegionType &outputRegionForThread,
-                        ThreadIdType itkNotUsed(threadId) )
+::DynamicThreadedGenerateData( const OutputImageRegionType &outputRegionForThread)
   {
   InputIteratorType it( this->GetInput(), outputRegionForThread );
 

--- a/Source/itkTransformDeformationFieldFilter.h
+++ b/Source/itkTransformDeformationFieldFilter.h
@@ -1,5 +1,5 @@
-#ifndef __itkTransformDeformationFieldFilter_h
-#define __itkTransformDeformationFieldFilter_h
+#ifndef itkTransformDeformationFieldFilter_h
+#define itkTransformDeformationFieldFilter_h
 
 #include <itkObject.h>
 #include <itkImageToImageFilter.h>
@@ -25,10 +25,12 @@ class TransformDeformationFieldFilter
 public:
   typedef TInput  InputDataType;
   typedef TOutput OutputDataType;
+
   typedef ImageToImageFilter
   <Image<itk::Vector<InputDataType, NDimensions>, NDimensions>,
    Image<itk::Vector<OutputDataType, NDimensions>, NDimensions> >
   Superclass;
+
   typedef itk::Vector<InputDataType, NDimensions>        InputDeformationPixelType;
   typedef Image<InputDeformationPixelType, NDimensions>  InputDeformationFieldType;
   typedef itk::Vector<OutputDataType, NDimensions>       OutputDeformationPixelType;

--- a/Source/itkTransformDeformationFieldFilter.h
+++ b/Source/itkTransformDeformationFieldFilter.h
@@ -45,6 +45,9 @@ public:
   typedef Transform<OutputDataType, NDimensions, NDimensions>          TransformType;
   typedef typename OutputDeformationFieldType::RegionType              OutputImageRegionType;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(TransformDeformationFieldFilter, ImageToImageFilter);
+
   itkNewMacro( Self );
 // /Set the transform
   itkSetObjectMacro( Transform, TransformType );

--- a/Source/itkTransformDeformationFieldFilter.h
+++ b/Source/itkTransformDeformationFieldFilter.h
@@ -55,7 +55,7 @@ public:
   itkSetObjectMacro( Transform, TransformType );
 
 // /Get the time of the last modification of the object
-  unsigned long GetMTime() const;
+  unsigned long GetMTime() const override;
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */
@@ -70,11 +70,11 @@ protected:
 
   void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId );
 
-  void BeforeThreadedGenerateData();
+  void BeforeThreadedGenerateData() override;
 
-  void GenerateOutputInformation();
+  void GenerateOutputInformation() override;
 
-  void GenerateInputRequestedRegion();
+  void GenerateInputRequestedRegion() override;
 
 private:
   typename TransformType::Pointer m_Transform;

--- a/Source/itkTransformDeformationFieldFilter.h
+++ b/Source/itkTransformDeformationFieldFilter.h
@@ -68,7 +68,7 @@ public:
 protected:
   TransformDeformationFieldFilter();
 
-  void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId );
+  void DynamicThreadedGenerateData( const OutputImageRegionType & outputRegionForThread) override;
 
   void BeforeThreadedGenerateData() override;
 

--- a/Source/itkTransformDeformationFieldFilter.txx
+++ b/Source/itkTransformDeformationFieldFilter.txx
@@ -1,5 +1,5 @@
-#ifndef __TransformDeformationFieldFilter_txx
-#define __TransformDeformationFieldFilter_txx
+#ifndef itkTransformDeformationFieldFilter_txx
+#define itkTransformDeformationFieldFilter_txx
 
 #include "itkTransformDeformationFieldFilter.h"
 

--- a/Source/itkTransformDeformationFieldFilter.txx
+++ b/Source/itkTransformDeformationFieldFilter.txx
@@ -48,8 +48,7 @@ TransformDeformationFieldFilter<TInput, TOutput, NDimensions>
 template <class TInput, class TOutput, int NDimensions>
 void
 TransformDeformationFieldFilter<TInput, TOutput, NDimensions>
-::ThreadedGenerateData( const OutputImageRegionType &outputRegionForThread,
-                        ThreadIdType itkNotUsed(threadId) )
+::DynamicThreadedGenerateData( const OutputImageRegionType &outputRegionForThread)
   {
   OutputDeformationFieldPointerType outputImagePtr = this->GetOutput( 0 );
   InputIteratorType                 it( this->GetInput( 0 ), outputRegionForThread );

--- a/Source/itkWarpTransform3D.h
+++ b/Source/itkWarpTransform3D.h
@@ -20,6 +20,7 @@ public:
   typedef WarpTransform3D                                    Self;
   typedef Transform<FieldDataType, 3, 3>                     Superclass;
   typedef typename Superclass::JacobianType                  JacobianType;
+  typedef typename Superclass::JacobianPositionType          JacobianPositionType;
   typedef typename Superclass::InputPointType                InputPointType;
   typedef typename Superclass::InputVectorType               InputVectorType;
   typedef typename Superclass::InputVnlVectorType            InputVnlVectorType;
@@ -55,6 +56,13 @@ public:
   void ComputeJacobianWithRespectToPosition(
     const InputPointType & itkNotUsed(x),
     JacobianType & itkNotUsed(j) ) const override
+  {
+    itkExceptionMacro("ComputeJacobianWithRespectToPosition is not implemented for WarpTransform3D");
+  }
+
+  void ComputeJacobianWithRespectToPosition(
+    const InputPointType & itkNotUsed(x),
+    JacobianPositionType & itkNotUsed(j) ) const override
   {
     itkExceptionMacro("ComputeJacobianWithRespectToPosition is not implemented for WarpTransform3D");
   }

--- a/Source/itkWarpTransform3D.h
+++ b/Source/itkWarpTransform3D.h
@@ -1,5 +1,5 @@
-#ifndef __itkWarpTransform3D_h
-#define __itkWarpTransform3D_h
+#ifndef itkWarpTransform3D_h
+#define itkWarpTransform3D_h
 
 #include <itkTransform.h>
 #include "dtiprocessFiles/dtitypes.h"
@@ -42,17 +42,19 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  virtual::itk::LightObject::Pointer CreateAnother(void) const;
+  ::itk::LightObject::Pointer CreateAnother(void) const override;
 
-  itkTypeMacro( WarpTransform3D, Transform );
-  OutputPointType TransformPoint( const InputPointType & inputPoint ) const;
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(WarpTransform3D, Transform);
 
+  OutputPointType TransformPoint( const InputPointType & inputPoint ) const override;
 
-  virtual void ComputeJacobianWithRespectToParameters(const InputPointType  & p, JacobianType & jacobian ) const;
+  void ComputeJacobianWithRespectToParameters(const InputPointType  & p,
+      JacobianType & jacobian ) const override;
 
-  virtual void ComputeJacobianWithRespectToPosition(
+  void ComputeJacobianWithRespectToPosition(
     const InputPointType & itkNotUsed(x),
-    JacobianType & itkNotUsed(j) ) const
+    JacobianType & itkNotUsed(j) ) const override
   {
     itkExceptionMacro("ComputeJacobianWithRespectToPosition is not implemented for WarpTransform3D");
   }
@@ -66,20 +68,20 @@ public:
 
   using Superclass::TransformVector;
   /**  Method to transform a vector. */
-  virtual OutputVectorType    TransformVector(const InputVectorType &) const
+  OutputVectorType    TransformVector(const InputVectorType &) const override
   {
     itkExceptionMacro("TransformVector(const InputVectorType &) is not implemented for WarpTransform3D");
   }
 
   /**  Method to transform a vnl_vector. */
-  virtual OutputVnlVectorType TransformVector(const InputVnlVectorType &) const
+  OutputVnlVectorType TransformVector(const InputVnlVectorType &) const override
   {
     itkExceptionMacro("TransformVector(const InputVnlVectorType &) is not implemented for WarpTransform3D");
   }
 
   using Superclass::TransformCovariantVector;
   /**  Method to transform a CovariantVector. */
-  virtual OutputCovariantVectorType TransformCovariantVector(const InputCovariantVectorType &) const \
+  OutputCovariantVectorType TransformCovariantVector(const InputCovariantVectorType &) const  override
   {
     itkExceptionMacro(
       "TransformCovariantVector(const InputCovariantVectorType & is not implemented for WarpTransform3D");
@@ -93,15 +95,15 @@ protected:
   /**This is a dummy function. This class does not allow to set the
    * transform parameters through this function. Use
    * SetDeformationField() to set the transform.*/
-  virtual void  SetParameters(const ParametersType &)
+  void  SetParameters(const ParametersType &) override
   {
-  };
+  }
   /**This is a dummy function. This class does not allow to set the
    * transform fixed parameters through this function. Use
    * SetDeformationField() to set the transform */
-  virtual void  SetFixedParameters(const ParametersType &)
+  void  SetFixedParameters(const ParametersType &) override
   {
-  };
+  }
 
   WarpTransform3D();
   void operator=(const Self &); // purposely not implemented

--- a/Source/itkWarpTransform3D.h
+++ b/Source/itkWarpTransform3D.h
@@ -47,7 +47,6 @@ public:
   itkTypeMacro( WarpTransform3D, Transform );
   OutputPointType TransformPoint( const InputPointType & inputPoint ) const;
 
-  const JacobianType & GetJacobian( const InputPointType & inputPoint ) const;
 
   virtual void ComputeJacobianWithRespectToParameters(const InputPointType  & p, JacobianType & jacobian ) const;
 
@@ -112,7 +111,6 @@ protected:
   DeformationImagePointerType m_DeformationField;
 //  Vector< double , 3 > m_OutputSpacing ;
   Size<3>              m_SizeForJacobian;
-  mutable JacobianType m_NonThreadsafeSharedJacobian;
 };
 
 } // end namespace itk

--- a/Source/itkWarpTransform3D.txx
+++ b/Source/itkWarpTransform3D.txx
@@ -52,7 +52,6 @@ WarpTransform3D<FieldData>
     m_DerivativeWeights[i] = 1.0;
     }
   m_SizeForJacobian.Fill( 1 );
-  this->m_NonThreadsafeSharedJacobian.SetSize( 3, 3 );
 }
 
 // Returns the position of the transformed point. If input point is outside of the deformation
@@ -75,17 +74,6 @@ WarpTransform3D<FieldData>
   transformedPoint = inputPoint + displacement;
   return transformedPoint;
 }
-
-// Copied and modified from dtiprocess
-// available there: http://www.nitrc.org/projects/dtiprocess/
-template <class FieldData>
-const typename WarpTransform3D<FieldData>::JacobianType
-& WarpTransform3D<FieldData>
-::GetJacobian( const InputPointType &inputPoint ) const
-  {
-  this->ComputeJacobianWithRespectToParameters( inputPoint, this->m_NonThreadsafeSharedJacobian );
-  return this->m_NonThreadsafeSharedJacobian;
-  }
 
 template <class FieldData>
 void

--- a/Source/itkWarpTransform3D.txx
+++ b/Source/itkWarpTransform3D.txx
@@ -1,3 +1,7 @@
+
+#ifndef itkWarpTransform3D_txx
+#define itkWarpTransform3D_txx
+
 #include "itkWarpTransform3D.h"
 
 namespace itk
@@ -44,7 +48,7 @@ WarpTransform3D<FieldData>
 ::WarpTransform3D() :
   Superclass( 1 )
 {
-  m_DeformationField = 0;
+  m_DeformationField = nullptr;
 //  m_OutputSpacing.Fill( 1 ) ;
   for( int i = 0; i < 3; i++ )
     {
@@ -125,3 +129,5 @@ WarpTransform3D<FieldData>
 }
 
 } // end of namespace
+
+#endif


### PR DESCRIPTION
This is ready for final review. 

All tests pass against both ITKv4 and ITKv5.

To build against ITKv4, all commits expect the **last two** should be used.